### PR TITLE
:bug: correct link to `CONTIBUTING` in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-:memo: :lipstick: :new: :bomb: :bug: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs102/blob/contribute/CONTRIBUTING.md#style-guidelines).
+:memo: :lipstick: :new: :bomb: :bug: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs102/blob/main/CONTRIBUTING.md#style-guidelines).
 
 
 ### Issues or PRs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-:memo: :lipstick: :new: :bomb: :bug: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs102/blob/contribute/CONTRIBUTING.md#style-guidelines)
+:memo: :lipstick: :new: :bomb: :bug: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs102/blob/main/CONTRIBUTING.md#style-guidelines)
 
 
 ### Issues or PRs


### PR DESCRIPTION
### Issues or PRs
#81 

### What
Correcting the link to the contributing guidelines. They were linking to a non-existent branch.

### Why
404 ded bad.

### Testing
Rich diff view.er
