### PR TITLE
:memo: Change :baby: to :medal_sports: for "good first issue" label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,9 @@ Also keep in mind that there are categories of content
     * :lipstick: `:lipstick:` Improving the format/structure/layout of content/files
     * :bug: `:bug:` Bug in Code or Typo
     * :telescope: `:telescope:` Using different words/code for the same ideas
-    * :art: `:art:` Relating to figures/image
+    * :art: `:art:` Relating to figures/images
     * :dancers: `:dancers:` This issue or pull request already exists
-    * :baby: `:baby:` Good for newcomers
+    * :medal_sports: `:medal_sports:` Good for newcomers
     * :eyes: `:eyes:` Extra attention is needed
     * :question: `:question:` Further information is requested
   


### PR DESCRIPTION
### Related Issues or PRs
Closes #89 

### What
Change the good first issue label's emoji to :medal_sports: `:medal_sports:` from :baby: `:baby:`. Also threw in a change in the text from "image" -> "images" to match the plural of "figures" used. 

### Why
The baby :baby: may be interpreted negatively and may discourage participation if individuals feel that they are being insulted. Was going for :1st_place_medal: `:1st_place_medal:`, but that was too long for the label text. 

### Where
CONTRIBUTING.md
There is nothing to change in templates as it was not included in the emoji list.
