### PR TITLE
:mortar_board: Topic9 Add section on growth functions

### DIFF
--- a/src/site/conf.py
+++ b/src/site/conf.py
@@ -28,7 +28,7 @@ import sys
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.imgmath']
+extensions = ['sphinx.ext.mathjax']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/src/site/topic9.rst
+++ b/src/site/topic9.rst
@@ -37,7 +37,7 @@ Growth Function
     * How does the time to run the algorithm :math:`t(n)` change as :math:`n` changes?
 
 * We call :math:`t(n)` the *growth function*
-* Notice how :math:`t(n)` is a function of :math:`n'
+* Notice how :math:`t(n)` is a function of :math:`n`
     * This means the amount of time needed depends on :math:`n`
 
 * Here is an arbitrary growth function

--- a/src/site/topic9.rst
+++ b/src/site/topic9.rst
@@ -32,6 +32,63 @@ Time Complexity
 Growth Function
 ===============
 
+* We want to understand the relationship between the size of the input :math:`n` and the time it takes to run the algorithm :math:`t(n)`
+    * The size of input could be the length of a list to be sorted
+    * How does the time to run the algorithm :math:`t(n)` change as :math:`n` changes?
+
+* We call :math:`t(n)` the *growth function*
+* Notice how :math:`t(n)` is a function of :math:`n'
+    * This means the amount of time needed depends on :math:`n`
+
+* Here is an arbitrary growth function
+    * At this stage, don't worry about how we got it as we will come back to that
+
+    :math:`t(n) = 15n^{2} + 25n`
+
+
+.. image:: img/complexity_table.png
+   :width: 500 px
+   :align: center
+
+* This table shows how each of the parts of the :math:`t(n)` growth function change as :math:`n` grows
+* Take note as to which part can be blamed for most of the whole :math:`t(n)`
+
+* When :math:`n` is small, which part of the expression gives a larger calue?
+* As :math:`n` **grows**, which becomes bigger?
+* How much do the constants (:math:`15` and :math:`45`) impact the values?
+    * Do they affect how big the numbers change as :math:`n` increases?
+
+
+.. image:: img/complexity_growth0.png
+   :width: 750 px
+   :align: center
+
+* This plot compares the parts of the function to the function itself
+* Notice the scale of the axes
+* See how the part that grows linearly, :math:`45n`, appears to be a horizontal line at this scale
+* Also notice how the blue :math:`15n^{2}` line is perfectly covered by the green :math:`15n^{2} + 45n` line
+
+* In other words, the :math:`45n` part of the function is effectively inconsequential when looking at the bigger picture
+* Given this, and the fact that constants only scale the values, we say that the :math:`n^{2}` is the **dominant** term
+
+.. warning::
+
+    One thing students tend to miss when first learning about computational complexity is that the function tells us
+    how things change relative to :math:`n`. At this stage, we're not worrying about any absolute values.
+
+    For example, given this growth function...
+
+        .. math::
+
+            t(n) = n^{2} + 999n
+
+    you may say that the :math:`999n` part of the function is going to dominate for all values :math:`n < 999`, which is
+    true. However, this is not the point of complexity analysis. The point is identifying which part of the function
+    **grows** faster, and in this example, :math:`n^{2}` absolutely grows faster.
+
+    This is **not** to suggest that the observation of :math:`n < 999` is not important or valuable; this is only to
+    highlight that it's about change and growth.
+
 
 Asymptotic Growth
 =================

--- a/src/site/topic9.rst
+++ b/src/site/topic9.rst
@@ -53,7 +53,7 @@ Growth Function
 * This table shows how each of the parts of the :math:`t(n)` growth function change as :math:`n` grows
 * Take note as to which part can be blamed for most of the whole :math:`t(n)`
 
-* When :math:`n` is small, which part of the expression gives a larger calue?
+* When :math:`n` is small, which part of the expression gives a larger value?
 * As :math:`n` **grows**, which becomes bigger?
 * How much do the constants (:math:`15` and :math:`45`) impact the values?
     * Do they affect how big the numbers change as :math:`n` increases?


### PR DESCRIPTION
### What
Add subsection to Topic9 on growth functions. 
Add a warning about how we focus on growth & change. 
Change imgmath to mathjax in conf.py.

## Why
imgmath is switched for mathjax as it does not depend on LaTeX.

### Where
Topic8
conf.py

### Testing
Since I am using `:math:` in a bunch of places, I did some local tests to see how things rendered. :lipstick: 
