### PR TITLE
:mortar_board: Topic10 Add section on queue operations

### DIFF
--- a/src/site/topic10.rst
+++ b/src/site/topic10.rst
@@ -22,7 +22,7 @@ Queue Operations
 
 .. warning::
 
-    If you look at `Java's Queue Interface <https://docs.oracle.com/javase/7/docs/api/java/util/Queue.html>`_, you will
+    If you look at `Java's Queue Interface <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Queue.html>`_, you will
     see that they use ``add``, ``remove``, and ``element`` along with ``offer``, ``poll``, and ``peek``. The first three
     are the same as our ``enqueue``, ``dequeue``, and ``first`` and the other three are the same, but do not throw
     exceptions.

--- a/src/site/topic10.rst
+++ b/src/site/topic10.rst
@@ -10,7 +10,7 @@ Queue Operations
     * Remove something from the collection
     * Look at something, but do not remove it
 
-* Within the context of a Queue, we have
+* Within the context of a queue, we have
     * **Enqueue**
         * Add something to the rear/tail
     * **Dequeue**

--- a/src/site/topic10.rst
+++ b/src/site/topic10.rst
@@ -5,6 +5,31 @@ Topic #10 --- The Queue ADT
 Queue Operations
 ================
 
+* Like other collections, we need ways to
+    * Add something to the collection
+    * Remove something from the collection
+    * Look at something, but do not remove it
+
+* Within the context of a Queue, we have
+    * **Enqueue**
+        * Add something to the rear/tail
+    * **Dequeue**
+        * Remove something from the front/head
+    * **First**
+        * Look at the thing at the front/head of the queue, but do not remove it
+
+* We will also want our ``isEmpty``, ``size``, and ``toString``
+
+.. warning::
+
+    If you look at `Java's Queue Interface <https://docs.oracle.com/javase/7/docs/api/java/util/Queue.html>`_, you will
+    see that they use ``add``, ``remove``, and ``element`` along with ``offer``, ``poll``, and ``peek``. The first three
+    are the same as our ``enqueue``, ``dequeue``, and ``first`` and the other three are the same, but do not throw
+    exceptions.
+
+    We will use the ``enqueue``, ``dequeue``, and ``first`` names as it is what they are `typically called when referring
+    to a Queue ADT <https://en.wikipedia.org/wiki/Queue_(abstract_data_type)>`_.
+
 
 Example Uses
 ============


### PR DESCRIPTION
### What
Add a section on the abstract queue operations: `enqueue`, `dequeue`, and `first`. 

### Where
Topic10.rst

### Additional Notes
[It was decided to use the traditional naming for queue operations.](https://en.wikipedia.org/wiki/Queue_(abstract_data_type))
