### PR TITLE
:bug: Fix function names in stack tests

### DIFF
--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -196,7 +196,7 @@ Testing LinkedStack
 
         @Test
         @DisplayName("Pushing items updates the size of the stack.")
-        void PushingUpdatesSize() {
+        void pushingUpdatesSize() {
             Stack<Integer> stack = new LinkedStack<>();
             stack.push(99);
             stack.push(101);
@@ -205,7 +205,7 @@ Testing LinkedStack
 
         @Test
         @DisplayName("Pushing an item results in it being on the top.")
-        void PushedItemIsTopOfStack() {
+        void pushedItemIsTopOfStack() {
             Stack<Integer> stack = new LinkedStack<>();
             stack.push(99);
             assertEquals(99, stack.peek());

--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -31,7 +31,7 @@ class ArrayStackTest {
 
     @Test
     @DisplayName("Pushing items updates the size of the stack.")
-    void PushingUpdatesSize() {
+    void pushingUpdatesSize() {
         Stack<Integer> stack = new ArrayStack<>();
         stack.push(99);
         stack.push(101);
@@ -40,7 +40,7 @@ class ArrayStackTest {
 
     @Test
     @DisplayName("Pushing an item results in it being on the top.")
-    void PushedItemIsTopOfStack() {
+    void pushedItemIsTopOfStack() {
         Stack<Integer> stack = new ArrayStack<>();
         stack.push(99);
         assertEquals(99, stack.peek());

--- a/src/test/java/LinkedStackTest.java
+++ b/src/test/java/LinkedStackTest.java
@@ -31,7 +31,7 @@ class LinkedStackTest {
 
     @Test
     @DisplayName("Pushing items updates the size of the stack.")
-    void PushingUpdatesSize() {
+    void pushingUpdatesSize() {
         Stack<Integer> stack = new LinkedStack<>();
         stack.push(99);
         stack.push(101);
@@ -40,7 +40,7 @@ class LinkedStackTest {
 
     @Test
     @DisplayName("Pushing an item results in it being on the top.")
-    void PushedItemIsTopOfStack() {
+    void pushedItemIsTopOfStack() {
         Stack<Integer> stack = new LinkedStack<>();
         stack.push(99);
         assertEquals(99, stack.peek());


### PR DESCRIPTION
### What
Ensure function names start with lower case.

### Why
Follows convention. 
As of now, two functions started with `Pushing...`. 

### Where
LinkedStackTest.java
ArrayStackTest.java
topic8.rst