### PR TITLE
:telescope: :mortar_board: Change `EmptyStackException` to `NoSuchElementException` for stacks

### DIFF
--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -1,4 +1,4 @@
-import java.util.EmptyStackException;
+import java.util.NoSuchElementException;
 
 public class ArrayStack<T> implements Stack<T> {
 
@@ -56,7 +56,7 @@ public class ArrayStack<T> implements Stack<T> {
     @Override
     public T pop() {
         if (isEmpty()) {
-            throw new EmptyStackException();
+            throw new NoSuchElementException("Popping from an empty stack.");
         }
         top--;
         T returnElement = stack[top];
@@ -67,7 +67,7 @@ public class ArrayStack<T> implements Stack<T> {
     @Override
     public T peek() {
         if (isEmpty()) {
-            throw new EmptyStackException();
+            throw new NoSuchElementException("Popping from an empty stack.");
         }
         return stack[top - 1];
     }

--- a/src/main/java/LinkedStack.java
+++ b/src/main/java/LinkedStack.java
@@ -1,4 +1,4 @@
-import java.util.EmptyStackException;
+import java.util.NoSuchElementException;
 
 public class LinkedStack<T> implements Stack<T> {
 
@@ -21,7 +21,7 @@ public class LinkedStack<T> implements Stack<T> {
     @Override
     public T pop() {
         if (isEmpty()) {
-            throw new EmptyStackException();
+            throw new NoSuchElementException("Popping from an empty stack.");
         }
         T returnElement = top.getData();
         top = top.getNext();
@@ -32,7 +32,7 @@ public class LinkedStack<T> implements Stack<T> {
     @Override
     public T peek() {
         if (isEmpty()) {
-            throw new EmptyStackException();
+            throw new NoSuchElementException("Popping from an empty stack.");
         }
         return top.getData();
     }

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -332,11 +332,11 @@ Code
         myStack.peek();
     }
     catch (NoSuchElementException e) {
-        System.out.println("Caught exception on peek.");
+        e.printStackTrace();
     }
     try {
         myStack.pop();
     }
     catch (NoSuchElementException e) {
-        System.out.println("Caught exception on pop.");
+        e.printStackTrace();
     }

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -177,7 +177,7 @@ Pop and Peek
 
         public T pop() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException();
             }
             top--;
             T returnElement = stack[top];
@@ -187,7 +187,7 @@ Pop and Peek
 
         public T peek() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException();
             }
             return stack[top - 1];
         }
@@ -222,7 +222,7 @@ Pop and Peek
 
 .. warning::
 
-    To use the ``EmptyStackException``, we will need to import it --- ``import java.util.EmptyStackException;``
+    To use the ``NoSuchElementException``, we will need to import it --- ``import java.util.NoSuchElementException;``
 
 size and isEmpty
 ^^^^^^^^^^^^^^^^
@@ -331,12 +331,12 @@ Code
     try {
         myStack.peek();
     }
-    catch (EmptyStackException e) {
+    catch (NoSuchElementException e) {
         System.out.println("Caught exception on peek.");
     }
     try {
         myStack.pop();
     }
-    catch (EmptyStackException e) {
+    catch (NoSuchElementException e) {
         System.out.println("Caught exception on pop.");
     }

--- a/src/site/topic8-nested.rst
+++ b/src/site/topic8-nested.rst
@@ -40,7 +40,7 @@ Nesting in LinkedStack
     :linenos:
     :emphasize-lines: 65-94
 
-    import java.util.EmptyStackException;
+    import java.util.NoSuchElementException;
 
     public class LinkedStack<T> implements Stack<T> {
 
@@ -63,7 +63,7 @@ Nesting in LinkedStack
         @Override
         public T pop() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException("Popping from an empty stack.");
             }
             T returnElement = top.getData();
             top = top.getNext();
@@ -74,7 +74,7 @@ Nesting in LinkedStack
         @Override
         public T peek() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException("Popping from an empty stack.");
             }
             return top.getData();
         }

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -51,7 +51,7 @@ Implementation
 .. code-block:: java
     :linenos:
 
-    import java.util.EmptyStackException;
+    import java.util.NoSuchElementException;
 
     public class LinkedStack<T> implements Stack<T> {
 
@@ -95,7 +95,7 @@ Pop & Peek
         @Override
         public T pop() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException();
             }
             T returnElement = top.getData();
             top = top.getNext();
@@ -106,7 +106,7 @@ Pop & Peek
         @Override
         public T peek() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException();
             }
             return top.getData();
         }
@@ -224,17 +224,17 @@ Testing LinkedStack
         }
 
         @Test
-        @DisplayName("Pop throws EmptyStackException when stack is empty.")
+        @DisplayName("Pop throws NoSuchElementException when stack is empty.")
         void popEmptyStackThrowsException() {
             Stack<Integer> stack = new LinkedStack<>();
-            assertThrows(EmptyStackException.class, () -> stack.pop());
+            assertThrows(NoSuchElementException.class, () -> stack.pop());
         }
 
         @Test
-        @DisplayName("Peek throws EmptyStackException when stack is empty.")
+        @DisplayName("Peek throws NoSuchElementException when stack is empty.")
         void peekEmptyStackThrowsException() {
             Stack<Integer> stack = new LinkedStack<>();
-            assertThrows(EmptyStackException.class, () -> stack.peek());
+            assertThrows(NoSuchElementException.class, () -> stack.peek());
         }
 
 
@@ -259,7 +259,7 @@ Introduction Errors for Fun
         @Override
         public T pop() {
             if (isEmpty()) {
-                throw new EmptyStackException();
+                throw new NoSuchElementException();
             }
             T returnElement = top.getData();
             top = top.getNext();
@@ -339,14 +339,14 @@ Playing
     try {
         myStack.peek();
     }
-    catch (EmptyStackException e) {
-        System.out.println("Caught exception on peek.");
+    catch (NoSuchElementException e) {
+        System.out.println(e.getMessage());
     }
     try {
         myStack.pop();
     }
-    catch (EmptyStackException e) {
-        System.out.println("Caught exception on pop.");
+    catch (NoSuchElementException e) {
+        System.out.println(e.getMessage());
     }
 
 For next time

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -340,13 +340,13 @@ Playing
         myStack.peek();
     }
     catch (NoSuchElementException e) {
-        System.out.println(e.getMessage());
+        e.printStackTrace();
     }
     try {
         myStack.pop();
     }
     catch (NoSuchElementException e) {
-        System.out.println(e.getMessage());
+        e.printStackTrace();
     }
 
 For next time

--- a/src/site/topic9.rst
+++ b/src/site/topic9.rst
@@ -297,7 +297,7 @@ Popping
     // LinkedStack's pop
     public T pop() {
         if (isEmpty()) {
-            throw new EmptyStackException();
+            throw new NoSuchElementException();
         }
         T returnElement = top.getData();
         top = top.getNext();
@@ -311,7 +311,7 @@ Popping
     // ArrayStack's pop
     public T pop() {
         if (isEmpty()) {
-            throw new EmptyStackException();
+            throw new NoSuchElementException();
         }
         top--;
         T returnElement = stack[top];

--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -1,7 +1,7 @@
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.EmptyStackException;
+import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -72,16 +72,16 @@ class ArrayStackTest {
     }
 
     @Test
-    @DisplayName("Pop throws EmptyStackException when stack is empty.")
+    @DisplayName("Pop throws NoSuchElementException when stack is empty.")
     void popEmptyStackThrowsException() {
         Stack<Integer> stack = new ArrayStack<>();
-        assertThrows(EmptyStackException.class, () -> stack.pop());
+        assertThrows(NoSuchElementException.class, () -> stack.pop());
     }
 
     @Test
-    @DisplayName("Peek throws EmptyStackException when stack is empty.")
+    @DisplayName("Peek throws NoSuchElementException when stack is empty.")
     void peekEmptyStackThrowsException() {
         Stack<Integer> stack = new ArrayStack<>();
-        assertThrows(EmptyStackException.class, () -> stack.peek());
+        assertThrows(NoSuchElementException.class, () -> stack.peek());
     }
 }

--- a/src/test/java/LinkedStackTest.java
+++ b/src/test/java/LinkedStackTest.java
@@ -1,7 +1,7 @@
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.EmptyStackException;
+import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -59,17 +59,17 @@ class LinkedStackTest {
     }
 
     @Test
-    @DisplayName("Pop throws EmptyStackException when stack is empty.")
+    @DisplayName("Pop throws NoSuchElementException when stack is empty.")
     void popEmptyStackThrowsException() {
         Stack<Integer> stack = new LinkedStack<>();
-        assertThrows(EmptyStackException.class, () -> stack.pop());
+        assertThrows(NoSuchElementException.class, () -> stack.pop());
     }
 
     @Test
-    @DisplayName("Peek throws EmptyStackException when stack is empty.")
+    @DisplayName("Peek throws NoSuchElementException when stack is empty.")
     void peekEmptyStackThrowsException() {
         Stack<Integer> stack = new LinkedStack<>();
-        assertThrows(EmptyStackException.class, () -> stack.peek());
+        assertThrows(NoSuchElementException.class, () -> stack.peek());
     }
 
 }


### PR DESCRIPTION
### Related Issues or PRs
Closes #107 

### What
Replace the use of `EmptyStackException` for everything dealing with stacks. Also added messages to `NoSuchElementException`.

### Why
Although not needed, I think this will help with consistency :telescope:.
I also want to avoid  the question _why is there no_ `EmptyQueueException` _?_ 
Messages were added to the message to show that it's a thing. 

### Where
src/test/java/LinkedStackTest.java
src/test/java/ArrayStackTest.java
src/main/java/ArrayStack.java
src/main/java/LinkedStack.java
/src/site/topic6.rst
src/site/topic8.rst
src/site/topic8-nested.rst
src/site/topic9.rst

### How
`grep -R "EmptyStackException" .`

### Testing
Ran `grep -R "EmptyStackException" .` again.
