### PR TITLE
:telescope: :lipstick: Use `initialCapacity` for `ArrayStack` constructor

### DIFF
--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -6,8 +6,6 @@ public class ArrayStack<T> implements Stack<T> {
     private T[] stack;
     private int top;
 
-
-
     /**
      * Create an ArrayStack of the default capacity.
      */
@@ -19,15 +17,15 @@ public class ArrayStack<T> implements Stack<T> {
     /**
      * Create an ArrayStack with the specified size.
      *
-     * @param size      Starting size of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array.
      */
     @SuppressWarnings("unchecked")
-    public ArrayStack(int size) {
+    public ArrayStack(int initialCapacity) {
         top = 0;
         // Generic types cannot be instantiated so we cast.
         // This does generate a compile time warning that
         // is being suppressed with the @ annotation.
-        stack = (T[]) new Object[size];
+        stack = (T[]) new Object[initialCapacity];
     }
 
     @Override


### PR DESCRIPTION
### What
Change `size` to `initialCapacity` for creating the array in the `ArrayStack` constructor. Also format code and eliminate whitespace.

### Why
Although not _wrong_, size may get confused with capacity. 
size is also used for the queues. 

### Where
src/main/java/ArrayStack.java