### PR TITLE
:bug: :lipstick: :telescope: Remove extra \n at end of `toStrings` for data structures

### DIFF
--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -89,7 +89,7 @@ public class ArrayStack<T> implements Stack<T> {
             builder.append(stack[i]);
             builder.append(", ");
         }
-        builder.append("<-- Top\n");
+        builder.append("<-- Top");
         return builder.toString();
     }
 

--- a/src/main/java/LinkedQueue.java
+++ b/src/main/java/LinkedQueue.java
@@ -74,7 +74,6 @@ public class LinkedQueue<T> implements Queue<T> {
             builder.append(", ");
             currentNode = currentNode.getNext();
         }
-        builder.append("\n");
         return builder.toString();
     }
 

--- a/src/main/java/LinkedStack.java
+++ b/src/main/java/LinkedStack.java
@@ -58,7 +58,7 @@ public class LinkedStack<T> implements Stack<T> {
             currentNode = currentNode.getNext();
         }
         builder.delete(0, 2);
-        builder.append("<-- Top\n");
+        builder.append("<-- Top");
         return builder.toString();
     }
 

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -255,7 +255,7 @@ toString
             builder.append(stack[i]);
             builder.append(", ");
         }
-        builder.append("<-- Top\n");
+        builder.append("<-- Top");
         return builder.toString();
     }
 

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -152,7 +152,7 @@ toString
                 currentNode = currentNode.getNext();
             }
             builder.delete(0, 2);
-            builder.append("<-- Top\n");
+            builder.append("<-- Top");
             return builder.toString();
         }
 


### PR DESCRIPTION
### What
Currrently there is a newline character being added at the end of the `toString`. Remove this. 

### Why
No need for it. 

### Where
src/main/java/ArrayStack.java
src/main/java/LinkedStack.java
src/main/java/LinkedQueue.java
/src/site/topic6.rst

### Additional Notes
The extra newline is left in the `ContactList` example since it is too much effort to address and may just throw off the students starting out. 
