### PR TITLE
:mortar_board: Remove line numbers from playing code for easy copy/paste

### DIFF
--- a/src/site/topic11.rst
+++ b/src/site/topic11.rst
@@ -208,7 +208,6 @@ Playing Code
 ============
 
 .. code-block:: java
-    :linenos:
 
         // Create a LinkedQueue
         Queue<Integer> myQueue = new LinkedQueue<>();

--- a/src/site/topic3.rst
+++ b/src/site/topic3.rst
@@ -806,7 +806,6 @@ Code
 * If everything was done correctly, the following code should work
 
 .. code-block:: java
-    :linenos:
 
     public class SomeClass {
         public static void main(String[] args) {

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -276,7 +276,6 @@ Code
 * If everything was done correctly, the following code should work
 
 .. code-block:: java
-    :linenos:
 
     // Create an ArrayStack
     Stack<Integer> myStack = new ArrayStack<>(5);

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -293,7 +293,6 @@ Playing
     * ``ArrayStack`` -> ``LinkedStack``
 
 .. code-block:: java
-    :linenos:
 
     // Create a LinkedStack
     Stack<Integer> myStack = new LinkedStack<>();


### PR DESCRIPTION
### What
Remove the `:linenos :` from the playing code. 

### Why
If someone tries to copy/paste the code to play with it, they will get the line numbers too, making usign the code a real pain. 

### How
Literally only delete `:linenos:` from the `code-block`s

### Additional Notes
Although this is being done, #77 will still be a thing.
