### PR TITLE
:memo: Add note to templates on Where heading

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,6 +12,7 @@ Replace this text with a detailed description of why this is important.
 
 ### Where
 Replace this text with a detailed description of where the issue is or where it should be addressed.
+If the where is obvious because of _Files changed_, then you don't fill this in.
 
 ### How
 Replace this text with a detailed description of any suggestions on how to address.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,6 @@ Replace this text with a detailed description of why this is important.
 
 ### Where
 Replace this text with a detailed description of where the issue is or where it should be addressed.
-If the where is obvious because of _Files changed_, then you don't fill this in.
 
 ### How
 Replace this text with a detailed description of any suggestions on how to address.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,8 @@ Replace this text with a detailed description of what the change is.
 Replace this text with a detailed description of why this is important.
 
 ### Where
-Replace this text with a detailed description of where the change is and why (should it be an aside?).
+Replace this text with a detailed description of where the change is/should be and why (should it be an aside?). 
+If the where is obvious because of _Files changed_, then you don't fill this in. 
 
 ### How
 Replace this text with a detailed description of how it is addressed.


### PR DESCRIPTION
### What
Add a note to the where template letting people know not to worry about "Where" when it is obvious due to _Files changed_.

### Why
Seems silly and a waste of resources

### Where
Templates! :thinking: 

### Additional Notes
The "Where" probably makes more sense for the Issues template, but I can see it popping up in PRs every now and then. 
