### PR TITLE
:new: :mortar_board: Topic12 Warning on geeking out too hard on efficiency

### DIFF
--- a/src/site/topic12.rst
+++ b/src/site/topic12.rst
@@ -197,6 +197,22 @@ Discussion
 * With this special expression for updating the ``rear``, do we need it for updating the ``front``?
 * With this idea, will we ever run out of room in our array?
 
+.. warning::
+
+    Sometimes, *good enough is good enough*.
+
+    In this ``ArrayQueue`` implementation scenario, idea #3 is quite clearly the superior option and is not overly
+    difficult to implement. However, as you continue in computer science and work on more complex problems, sometimes
+    ease of implementation and maintainability become very important.
+
+    Better algorithms always exist, and a subpar implementation may do the trick, especially when your problem space is
+    small enough that performance doesn't matter.
+
+    Computational complexity is very important, but sometimes in practice we may lose the forrest through the trees. If
+    you can change your algorithm from :math:`O(n^{2})` to :math:`O(n)`, then you should probably do it. But then again,
+    if the updated algorithm will take you a day and you only need to run the algorithm once on a small problem, perhaps
+    :math:`O(n^{2})` is good enough.
+
 
 Implementing a Queue --- Array Container
 ========================================

--- a/src/site/topic12.rst
+++ b/src/site/topic12.rst
@@ -213,6 +213,8 @@ Discussion
     if the updated algorithm will take you a day and you only need to run the algorithm once on a small problem, perhaps
     :math:`O(n^{2})` is good enough.
 
+    Even worse, if you're trying to save a few *FLOPS* here and there, great, but if that's distracting you from other
+    more important issues, perhaps you should move on. 
 
 Implementing a Queue --- Array Container
 ========================================


### PR DESCRIPTION
### Related Issues or PRs
Related to #126 

### What
Add a warning about getting too bogged down by finding _the best_ algorithm. 

### Why
CS students do tend to get very focused on big O when often that can be a distraction (especially when it comes down to how our computers are engineered, but that's not addressed here). Adding a note that as they progress and work on more and more complex problems, sometimes a quick and dirty solution is the best option. 

### Where
In the discussion section of idea #3 since at that point we've seen three implementations 

### Additional Notes
In general, probably not a big problem for first year students, but it's defo a good call to include this as a talking point because it will become an issue. 
