### PR TITLE
:lipstick: :telescope: Update try/catch statements 

### DIFF
--- a/src/site/topic11.rst
+++ b/src/site/topic11.rst
@@ -261,13 +261,11 @@ Playing Code
         // Test first and dequeue throwing exception
         try {
             myQueue.first();
-        }
-        catch (NoSuchElementException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }
         try {
             myQueue.dequeue();
-        }
-        catch (NoSuchElementException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }

--- a/src/site/topic12.rst
+++ b/src/site/topic12.rst
@@ -460,13 +460,11 @@ Playing Code
         // Test first and dequeue throwing exception
         try {
             myQueue.first();
-        }
-        catch (NoSuchElementException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }
         try {
             myQueue.dequeue();
-        }
-        catch (NoSuchElementException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -329,13 +329,11 @@ Code
     // Test peek and pop throwing exception
     try {
         myStack.peek();
-    }
-    catch (NoSuchElementException e) {
+    } catch (NoSuchElementException e) {
         e.printStackTrace();
     }
     try {
         myStack.pop();
-    }
-    catch (NoSuchElementException e) {
+    } catch (NoSuchElementException e) {
         e.printStackTrace();
     }

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -348,13 +348,11 @@ Playing
     // Test peek and pop throwing exception
     try {
         myStack.peek();
-    }
-    catch (NoSuchElementException e) {
+    } catch (NoSuchElementException e) {
         e.printStackTrace();
     }
     try {
         myStack.pop();
-    }
-    catch (NoSuchElementException e) {
+    } catch (NoSuchElementException e) {
         e.printStackTrace();
     }


### PR DESCRIPTION
### Related Issues or PRs
Closes #140

### What
Remove the newline before the `catch` statements.

### Why
More typical formatting

### Where
Up to topic 12 and topic 16.

### How
ctrl + f

### Additional Notes
Should not be a problem in any of the .java files if using the formatter. As of now, without a formatter for the .rst files (#155), it may get missed within the topic pages.