### PR TITLE
:telescope: :mortar_board: Remove `toString` from `BinarySearchTree` interface

### DIFF
--- a/src/main/java/BinarySearchTree.java
+++ b/src/main/java/BinarySearchTree.java
@@ -121,6 +121,4 @@ public interface BinarySearchTree<T extends Comparable<? super T>> extends Itera
      * @return Level-order iterator for tree
      */
     Iterator<T> levelOrderIterator();
-
-    String toString();
 }


### PR DESCRIPTION
### What
Remove the `toString` from the `BinarySearchTree` interface. 

### Why
Not needed. 

### Where
`BinarySearchTree` interface. 

### How
I found it and hit the backspace button. 