### PR TITLE
:new: :mortar_board: Topic7 Add warning about head not being a node

### DIFF
--- a/src/site/topic7.rst
+++ b/src/site/topic7.rst
@@ -183,6 +183,13 @@ Deleting from the End
 Node Implementation
 ===================
 
+.. warning::
+
+    Note that ``head`` is **not** a node; ``head`` is a reference to a node. For example, ``head = someNode;`` and
+    ``head.setNext(someNode);`` have two very different meanings. The first means that our reference ``head`` will
+    refer to the node ``someNode``, while the second means that the node referenced by ``head``\'s ``next`` node
+    reference will refer to ``someNode``.
+
 
 .. image:: img/links_reference.png
    :width: 400 px


### PR DESCRIPTION
### What
Add a warning about emphasizing the difference between a Node and a referrence ot a Node. 

### Why
Although at this point they should be well aware of the difference between references and objects, this does still come up as a common area of confusion. 

### Where
Topic7 because that's the first place where links are referred to. 