### PR TITLE
:bug: Fix lab intros

### DIFF
--- a/src/site/lab2.rst
+++ b/src/site/lab2.rst
@@ -2,7 +2,8 @@
 Lab #2
 ******
 
-* Refer to the slides for this lab. You will find many of the answers to your questions there
+* Refer to the topic pages for this lab
+    * You will find many of the answers to your questions there
 * Feel free to use your laptop if you have it
 * I strongly encourage you to work with others in the lab
 * Ensure I have recorded your completion. Failure to do so will result in a grade of 0

--- a/src/site/lab3.rst
+++ b/src/site/lab3.rst
@@ -2,7 +2,8 @@
 Lab #3
 ******
 
-* Refer to the slides for this lab. You will find many of the answers to your questions there
+* Refer to the topic pages for this lab
+    * You will find many of the answers to your questions there
 * Feel free to use your laptop if you have it
 * I strongly encourage you to work with others in the lab
 * Ensure I have recorded your completion. Failure to do so will result in a grade of 0

--- a/src/site/lab4.rst
+++ b/src/site/lab4.rst
@@ -2,7 +2,8 @@
 Lab #4
 ******
 
-* Refer to the slides for this lab. You will find many of the answers to your questions there
+* Refer to the topic pages for this lab
+    * You will find many of the answers to your questions there
 * Feel free to use your laptop if you have it
 * I strongly encourage you to work with others in the lab
 * Ensure I have recorded your completion. Failure to do so will result in a grade of 0


### PR DESCRIPTION
### What
Change "refer to the slides" -> "refer to the topic pages"
Remove the period in the first point and move stuff after period to sub-point

### Why
There ain't no slides. 
I don't like the periods 