### PR TITLE
:robot: Change source for aws sync

### DIFF
--- a/.github/workflows/gradle-build-deploy.yml
+++ b/.github/workflows/gradle-build-deploy.yml
@@ -54,4 +54,4 @@ jobs:
 
     - name: Copy Files to the Website
       run: |
-        aws s3 sync ./site/* s3://modsurski.com/csci162 --delete
+        aws s3 sync ./site s3://modsurski.com/csci162 --delete


### PR DESCRIPTION
### Related Issues or PRs
#246 #241 #6 

### What
Change source to simply be `./source` instead of `./source/*`.

### Why
Because it's my next guess. Also because [docs](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html#examples) seem to suggest it's the dir I specify anyways

### Testing
Nope. 
