### PR TITLE
:bug: :mortar_board: Topic20 Fix constant time symbols

### DIFF
--- a/src/site/topic20.rst
+++ b/src/site/topic20.rst
@@ -29,7 +29,7 @@ Linear Search
 
 * We've also discussed the computational complexity
     * Worst case scenario, we look at every element in the array before we make a conclusion --- linear :math:`O(n)`
-    * Best case scenario, the thing we are looking for is the first element --- constant :math:`O(n)`
+    * Best case scenario, the thing we are looking for is the first element --- constant :math:`O(1)`
     * On average, the element will be in the middle --- linear :math:`O(n)` --- remember, we ignore non-dominant terms, and :math:`1/2` is a constant, which is dominated by a linear term
         * For every time it's the first element, it could be the last element in another search
         * For every time it's the 2nd element, it could be in the second last position in another search


### PR DESCRIPTION
### What
Change `O(n)` -> `O(1)` for constant time. 

### Why
Constant time is currently written incorrectly as `O(n)` 