### PR TITLE
:lipstick: :mortar_board: Topic20 Change how recursive binary search parameter values are passed

### DIFF
--- a/src/main/java/SearchingMethods.java
+++ b/src/main/java/SearchingMethods.java
@@ -47,10 +47,9 @@ public class SearchingMethods {
         if (haystack[midpoint].equals(needle)) {
             return midpoint;
         } else if (haystack[midpoint].compareTo(needle) > 0) {
-            highIndex = midpoint - 1;
+            return recursiveBinarySearch(needle, haystack, lowIndex, midpoint - 1);
         } else {
-            lowIndex = midpoint + 1;
+            return recursiveBinarySearch(needle, haystack, midpoint + 1, highIndex);
         }
-        return recursiveBinarySearch(needle, haystack, lowIndex, highIndex);
     }
 }

--- a/src/site/topic20.rst
+++ b/src/site/topic20.rst
@@ -204,11 +204,10 @@ Recursive
         if (haystack[midpoint].equals(needle)) {
             return midpoint;
         } else if (haystack[midpoint].compareTo(needle) > 0) {
-            highIndex = midpoint - 1;
+            return recursiveBinarySearch(needle, haystack, lowIndex, midpoint - 1);
         } else {
-            lowIndex = midpoint + 1;
+            return recursiveBinarySearch(needle, haystack, midpoint + 1, highIndex);
         }
-        return recursiveBinarySearch(needle, haystack, lowIndex, highIndex);
     }
 
 * If I wanted to call this method, I would start with ``lowIndex`` as ``0`` and ``highIndex`` as ``someHaystack.length``


### PR DESCRIPTION
### Related Issues or PRs
Closes #287 

### What
Change the recursive binary search to simply pass altered values as parameters for the recursive cases instead of modifying the original parameter values and passing them to the recursive case.

In other words, instead of modifying the value of, for example, `lowIndex = midpoint + 1`, just call the recursive function with `recursiveBinarySearch(needle, haystack, midpoint + 1, highIndex);`

### Why
It's nicer this way. 

### Testing
Tests were re-run to make sure nothign went wrong. :+1: 

### Additional Notes
Is this needed? No. 
Do I like it better this way? Yes.
