### PR TITLE
:bug: :lipstick: fix a bunch of sphinx warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # All built stuff
 out/*
+_build/
 
 # Log file
 *.log
@@ -17,9 +18,10 @@ out/*
 src/main/java/asn1/solution/
 
 
-# IntelliJ stuff
+# IDE stuff
 .idea
 *.iml
+.vscode
 
 # Build script
 build.sh

--- a/src/site/lab3.rst
+++ b/src/site/lab3.rst
@@ -28,6 +28,7 @@ Writing Tests
 -------------
 
 **Tips**
+
 * Make your test method names as descriptive as possible while still being brief
 * Follow some convention for your method names, something like ``methodConditionExpected()``
     * ``sizeOfEmptyCourseListReturnsZero()``

--- a/src/site/lab7.rst
+++ b/src/site/lab7.rst
@@ -15,7 +15,7 @@ Lab #7
 Making a Linked Sorted Bag
 ==========================
 
-We discussed the :doc:`ArraySortedBag implementation<../main/java/Node.java>`, now you will build a linked version.
+We discussed the :download:`ArraySortedBag implementation<../main/java/ArraySortedBag.java>`, now you will build a linked version.
 
 1. Create a project and make a class where you will put your main method
     * Perhaps call it ``Lab7``

--- a/src/site/topic15.rst
+++ b/src/site/topic15.rst
@@ -78,7 +78,8 @@ ArrayIndexedBag
         }
 
 
-* There are a couple things to note so far
+There are a couple things to note so far:
+
 1. We are importing something called ``Iterator``
     * Iterators are used for *iterating* over a collection
     * More on this later

--- a/src/site/topic17.rst
+++ b/src/site/topic17.rst
@@ -194,6 +194,6 @@ Finally
 For next time
 =============
 
-* Read the :doc:`aside on creating your own exceptions. </topic16-create>`
+* Read the :doc:`aside on creating your own exceptions. </topic17-create>`
 * Go back and read Chapter 3 Section 5
     * 2 pages

--- a/src/site/topic18.rst
+++ b/src/site/topic18.rst
@@ -25,7 +25,7 @@ Topic #18 --- Memory & The Call Stack
 Memory Allocation
 =================
 
-* Memory is broken down into two broad sections
+Memory is broken down into two broad sections:
 
 1. The Stack
     * Stores information about the current method running

--- a/src/site/topic22.rst
+++ b/src/site/topic22.rst
@@ -28,7 +28,7 @@ Binary Tree Definition
     * An empty tree
     * Or, a tree that has a root whose left and right subtrees are binary trees
 
-.. admonition::
+.. note::
 
    Based on this information, what would a *unary* tree be?
 
@@ -55,7 +55,7 @@ Traversals
 
 
 Pre-order
---------
+---------
 
 * A pre-order traversal is a common order to traverse a binary tree
 * The general idea is
@@ -82,7 +82,7 @@ Pre-order
 
 
 In-order
--------
+--------
 
 * An in-order traversal is another common traversal
 * The general idea is
@@ -109,7 +109,7 @@ In-order
 
 
 Post-order
----------
+----------
 
 * Take a wild guess at what this one will be
 

--- a/src/site/topic4.rst
+++ b/src/site/topic4.rst
@@ -161,7 +161,7 @@ Data Structures
     * We used an array to keep track of the ``Friend`` objects
     * Do a linear search through the array to find a specific ``Friend``
 
-* A large focus in this class will be both the *what* and the *how and how to keep them separate
+* A large focus in this class will be both the *what* and the *how* and how to keep them separate
     * The interface and the implementation
 
 .. warning::

--- a/src/site/topic5.rst
+++ b/src/site/topic5.rst
@@ -228,7 +228,7 @@ There has to be a Better Way!
 
 .. warning::
 
-    We do not actually need to include the ``<Type>`` on the instantiation side. From now on, for simplicity, I will use the *diamond operator*(``<>``) like so:
+    We do not actually need to include the ``<Type>`` on the instantiation side. From now on, for simplicity, I will use the *diamond operator* (``<>``) like so:
 
         .. code-block:: java
             :linenos:

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -200,12 +200,12 @@ Pop and Peek
 * What should we do when someone tries to ``pop`` or ``peek`` from an empty stack?
     * Ignore and do nothing?
     * Crash the program?
-    * ...
+    * Something else?
 
 * Hard to say
 * What should be done is not up to us as the people implementing the stack
 
-* As a rule, you should follow `the principal of least surprise<https://en.wikipedia.org/wiki/Principle_of_least_astonishment>`_
+* As a rule, you should follow `the principal of least surprise <https://en.wikipedia.org/wiki/Principle_of_least_astonishment>`_
 * Should we expect to get nothing back when requesting the top?
 * Perhaps it's more reasonable that the request was invalid in the first place
 


### PR DESCRIPTION
### What
I was bored this morning waiting for deployments, so I opted to resolve some sphinx warnings to kill time.

Also adding `_build` and `.vscode` to gitignore. Not sure why `_build` wasn't there (maybe my sphinx was weird?), and `.vscode` since that was what I used to do this.

### Why
Some pages had rendering issues, others were just sphinx being confused but mostly doing the right thing.

### How
IDEs are good at underlining warnings. I use them. In IDE preview was what I was using to render.

### Testing
`./gradlew clean site`

### Additional Notes
There are still some warnings.

```
         /snip/git/cs102/src/site/topic18.rst:38: WARNING: Bullet list ends without a blank line; unexpected unindent.
         /snip/git/cs102/src/site/topic19.rst:189: WARNING: Definition list ends without a blank line; unexpected unindent.
         /snip/git/cs102/src/site/topic19.rst:190: WARNING: Definition list ends without a blank line; unexpected unindent.
         /snip/git/cs102/src/site/topic19.rst:191: WARNING: Definition list ends without a blank line; unexpected unindent.
         /snip/git/cs102/src/site/topic19.rst:192: WARNING: Definition list ends without a blank line; unexpected unindent.
```
The indents are part of a recursion explanation, they are rendered properly though. The indent is due to mixing bullet types (`*` and `a`), but it also renders properly.  
There's also a bunch of "thing not in a toc-tree," which are intentional.