### PR TITLE
:art: Topic23 Resize image for the example of adding

### DIFF
--- a/src/site/topic23.rst
+++ b/src/site/topic23.rst
@@ -182,7 +182,7 @@ Add
 * Starting with an empty tree, follow the pseudocode to add the following 6 elements
 
 .. image:: img/binarysearchtree_add1.png
-   :width: 250 px
+   :width: 666 px
    :align: center
 
 


### PR DESCRIPTION
### What
Increase the size of the adding example image.

### Why
Too small. 

### How
It was set to 250px, but I made it 666px since I think it will match the image above it better. 