### PR TITLE
:art::lipstick: Topic14 Resize various images

### DIFF
--- a/src/site/topic14-careful.rst
+++ b/src/site/topic14-careful.rst
@@ -8,7 +8,7 @@ Topic #14 Aside --- Careful
 
 
 .. image:: img/inheritance_bad.png
-   :width: 500 px
+   :width: 750 px
    :align: center
 
 * There is nothing wrong with extending concrete classes, but this is where things can become problematic

--- a/src/site/topic14-careful.rst
+++ b/src/site/topic14-careful.rst
@@ -22,11 +22,11 @@ Rectangles and Squares
     * `And it's also amusingly known for being a problematic example <https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem>`_
 
 .. image:: img/inheritance_rectangle.png
-   :width: 500 px
+   :height: 250 px
    :align: center
 
 .. image:: img/inheritance_square.png
-   :width: 500 px
+   :height: 250 px
    :align: center
 
 * We all know that, in real life, a square is a special type a rectangle

--- a/src/site/topic14.rst
+++ b/src/site/topic14.rst
@@ -69,7 +69,7 @@ Collections Example
 ===================
 
 .. image:: img/inheritance_collections.png
-   :width: 666 px
+   :width: 750 px
    :align: center
    :target: https://en.wikipedia.org/wiki/Java_collections_framework
 

--- a/src/site/topic14.rst
+++ b/src/site/topic14.rst
@@ -69,7 +69,7 @@ Collections Example
 ===================
 
 .. image:: img/inheritance_collections.png
-   :width: 500 px
+   :width: 666 px
    :align: center
    :target: https://en.wikipedia.org/wiki/Java_collections_framework
 


### PR DESCRIPTION
### What
Resize some images in topic 14 so they are more appropriately sized. The square and rectangle in the aside are also sized based on height so it will be easier to get a matching size for the shapes. 

### Why
Some were too big, others too small. Ultimately, better viewing. 

## Where
The collections heirarchy image was too small
The joke image about inheritance in the aside was also too small
The Square was stupidly large
Rectangle was also too large