### PR TITLE
:bug: Topic2 Fix wrong character in comment

### DIFF
--- a/src/site/topic2.rst
+++ b/src/site/topic2.rst
@@ -117,7 +117,7 @@ Declaring & Assigning Variables
 .. code-block:: java
     :linenos:
 
-    // Java --- Declaring * Assigning
+    // Java --- Declaring & Assigning
     int anotherInt;                     // Declaration
     anotherInt = 11;                    // Assignment
     System.out.println(anotherInt);


### PR DESCRIPTION
### What
Change the `*` -> `&` in a comment

### Why
It should have been &. Must've fat fingered it. 

### Where
Comment showing how we can declare and then assign the values later in Java 