### PR TITLE
:bug: Topic2 Fix for loop comment

### DIFF
--- a/src/site/topic2.rst
+++ b/src/site/topic2.rst
@@ -720,7 +720,7 @@ For Loop
     :linenos:
     :emphasize-lines: 3
 
-    // Java --- for each loop
+    // Java --- for loop
     // Run loop 10 times (0 -- 9)
     for (int i = 0; i < 10; ++i) {
             System.out.println(i);


### PR DESCRIPTION
### What
Remove "each" from the for loop comment

### Why
Previous example was the _for each_ example, this example is the counting for loop

### Where
Counting for loop example. 

### Additional Notes
Will also be fixed in aside with C++ added. 
