### PR TITLE
:bug: Lab3 Fix link to lab2

### DIFF
--- a/src/site/lab3.rst
+++ b/src/site/lab3.rst
@@ -15,13 +15,13 @@ Lab #3
 Unit Testing
 ============
 
-We're going to write tests for our ``CourseList`` class from `:doc: Lab2 </lab2>`. :doc:`Topic 6's aside on testing will be of great help here </topic6-testing>`.
+We're going to write tests for our ``CourseList`` class from :doc:`Lab2 </lab2>`. :doc:`Topic 6's aside on testing will be of great help here </topic6-testing>`.
 
 
 Have a Working Implementation
 -----------------------------
 
-1. If you have not already, finish `:doc: Lab2 </lab2>`
+1. If you have not already, finish :doc:`Lab2 </lab2>`
 
 
 Writing Tests


### PR DESCRIPTION
### What
Fix the link to lab2. 

### Why
It was broken

### How
`` `:doc: Lab2 </lab2>` `` -> ``:doc:`Lab2 </lab2>` ``
