### PR TITLE
:lipstick: Labs Remove numbers from lab code

### DIFF
--- a/src/site/lab1.rst
+++ b/src/site/lab1.rst
@@ -33,7 +33,6 @@ Creating a Project
 4. Add a ``main`` method to your class and have it do ``Hello, world!``
 
     .. code-block:: java
-        :linenos:
 
         public static void main(String[] args) {
             System.out.println("Hello, world!");

--- a/src/site/lab4.rst
+++ b/src/site/lab4.rst
@@ -39,7 +39,6 @@ Implementing a Stack
 5. Test your ``ArrayStack`` with the following
 
     .. code-block:: java
-        :linenos:
 
             public static void main(String[] args) {
                 Stack<Integer> myStack = new ArrayStack<>();
@@ -72,7 +71,6 @@ Reversing a String
 
 
     .. code-block:: java
-        :linenos:
 
         public static void main(String[] args) {
             String alphabet = "abcdefghijklmnopqrstuvwxyz";

--- a/src/site/lab5.rst
+++ b/src/site/lab5.rst
@@ -31,7 +31,6 @@ Node Class
 3. Do a simple test to see if it works by making an instance in your main method and using the node's methods
 
     .. code-block:: java
-        :linenos:
 
         Node<Integer> myNode = new Node<>(5);
         // Use the node class' methods here
@@ -46,7 +45,6 @@ Create the Linked Structure
     b. Return a reference to the head of the linked structure
 
     .. code-block:: java
-        :linenos:
 
         public static <T> Node<T> makeLinkedStructure() {
             // Stuff
@@ -56,7 +54,6 @@ Create the Linked Structure
 2. Verify it works by adding this to your ``main`` method
 
     .. code-block:: java
-        :linenos:
 
         Node<Integer> head = makeLinkedStructure();
         Node<Integer> currentNode = head;
@@ -82,7 +79,6 @@ Adding to the Front of the Structure
     c. Return a reference to the new head of the linked structure
 
     .. code-block:: java
-        :linenos:
 
         public static <T> Node<T> addToFront(Node<T> head, T toAdd) {
             // Stuff
@@ -92,7 +88,6 @@ Adding to the Front of the Structure
 2. Verify it works by adding this to your ``main`` method
 
     .. code-block:: java
-        :linenos:
 
         head = addToFront(head, 99);
         currentNode = head;
@@ -111,7 +106,6 @@ Removing from the Front of the Structure
     c. Return a reference to the new head of the linked structure
 
     .. code-block:: java
-        :linenos:
 
         public static <T> Node<T> removeFromFront(Node<T> head) {
             // Stuff
@@ -121,7 +115,6 @@ Removing from the Front of the Structure
 2. Verify it works by adding this to your ``main`` method
 
     .. code-block:: java
-        :linenos:
 
         head = removeFromFront(head) ;
         currentNode = head;
@@ -141,7 +134,6 @@ Adding to the Middle of the Structure
     c. Return a reference to the head of the linked structure
 
     .. code-block:: java
-        :linenos:
 
         public static <T> Node<T> addToMiddle(Node<T> head, T toAdd, T addAfter) {
             // Stuff
@@ -151,7 +143,6 @@ Adding to the Middle of the Structure
 2. Verify it works by adding this to your ``main`` method
 
     .. code-block:: java
-        :linenos:
 
         head = addToMiddle(head, 99, 5);
         currentNode = head;
@@ -175,7 +166,6 @@ Removing from the Middle of the Structure
     c. Return a reference to the head of the linked structure
 
     .. code-block:: java
-        :linenos:
 
         public static <T> Node<T> removeFromMiddle(Node<T> head, T toRemove) {
             // Stuff
@@ -185,7 +175,6 @@ Removing from the Middle of the Structure
 2. Verify it works by adding this to your ``main`` method
 
     .. code-block:: java
-        :linenos:
 
         head = removeFromMiddle(head, 99) ;
         currentNode = head;

--- a/src/site/lab8.rst
+++ b/src/site/lab8.rst
@@ -22,7 +22,6 @@ Recursion Visualization
 * Try running the following in the visualizer
 
     .. code-block:: java
-        :linenos:
 
         public class Recursion {
             public static int sum(int n) {


### PR DESCRIPTION
### Related Issues or PRs
Same idea as #123 

### What
Remove the line numbers from the code blocks in the lab for easy copy/paste. Line numbers are great in general, but not when they are specifically told to copy/paste. 

### Why
When copying and pasting with the line numbers, it will compy the line numbers at the beginning of each line, which is a pain. 

### Where
A bunch of the labs. 

### How
ctrl-f :linenos: