### PR TITLE
🐛 Topic2 Remove cpp warning

### DIFF
--- a/src/site/topic2.rst
+++ b/src/site/topic2.rst
@@ -2,16 +2,6 @@
 Topic #2 --- Java vs. Python
 ****************************
 
-.. warning::
-
-    * For these, I will only go over the C++ details at a high level
-    * Getting into the nitty gritty of C++ is not the purpose of this aside
-    * Some of the concepts require knowledge of more advanced ideas that have not been covered yet
-        * If this happens, do not panic
-        * it probably makes more sense to revisit this later in the course
-    * For simplicity, some of the examples will use less than ideal implementations
-
-
 **Python**
 
 .. code-block:: python


### PR DESCRIPTION
### What
Remove the warning about Cpp at the top of topic2. 

### Why
It should not have been there. 

### Where
Topic of Topic2

### Testing
Build local

### Additional Notes
I think I remember wondering why a warning was not in the Cpp aside originally, so I added it there, so I'm betting I had originally had it hin the wrong spot. 
