### PR TITLE
:mortar_board: Asn1 `CountryCatalogue` Second Half

### DIFF
--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -93,6 +93,8 @@ Part 2 --- Country Catalogue
 
 #. Write a ``saveCatalogue`` method to save the string representing the ``CountryCatalogue`` to a specified file
     * The file name will be passed as a parameter
+    * This method will make use of ``throws IOException`` to help keep things simpler
+        * You will not need to worry about ``try`` and ``catch`` blocks in this method
     * ``this`` class' ``toString`` will be of use here
 
 

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -73,8 +73,7 @@ Part 2 --- Country Catalogue
 
 #. Have a method called ``numberCountriesOnContinent`` that takes a continent name as a parameter and returns the number of ``Country`` objects on that continent
 
-#. Write a method called ``filterCountriesByContinent`` that takes a continent name as a parameter and returns a ``Country`` array containing only the countries on the specified continent
-    * You may find ``numberCountriesOnContinent`` useful here
+#. Write a method called ``filterCountriesByContinent`` that takes a continent name as a parameter and returns a new ``CountryCatalogue`` instance containing only the countries on the specified continent
 
 #. A method called ``findCountryLargestPopulation`` that returns the ``Country`` with the largest population in the ``catalogue``
 

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -79,6 +79,12 @@ Part 2 --- Country Catalogue
 
 #. Have a method called ``findMostPopulousContinent`` that returns the name of the continent with the largest total population based on the countries in the ``catalogue``
 
+#. Write the ``toString`` method to return a ``String`` with each ``Country`` object's details on a separate line
+
+#. Write a ``saveCatalogue`` method to save the string representing the ``CountryCatalogue`` to a specified file
+
+
+
 Part 3 --- Testing
 ==================
 

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -77,7 +77,7 @@ Part 2 --- Country Catalogue
 
 #. A method called ``findCountryLargestPopulation`` that returns the ``Country`` with the largest population in the ``catalogue``
 
-#. Have a method called ``findMostPopulousContinent`` that returns the name of the continent with the total  
+#. Have a method called ``findMostPopulousContinent`` that returns the name of the continent with the largest total population based on the countries in the ``catalogue``
 
 Part 3 --- Testing
 ==================

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -93,7 +93,7 @@ Part 2 --- Country Catalogue
 
 #. Write a ``saveCatalogue`` method to save the string representing the ``CountryCatalogue`` to a specified file
     * The file name will be passed as a parameter
-    * ``toString`` will be of use here
+    * ``this`` class' ``toString`` will be of use here
 
 
 

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -75,7 +75,9 @@ Part 2 --- Country Catalogue
 
 #. Write a method called ``filterCountriesByContinent`` that takes a continent name as a parameter and returns a ``Country`` array containing only the countries on the specified continent
 
+#. A method called ``findCountryLargestPopulation`` that returns the ``Country`` with the largest population in the ``catalogue``
 
+#. Have a method called ``findMostPopulousContinent`` that returns the name of the continent with the total  
 
 Part 3 --- Testing
 ==================

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -74,14 +74,26 @@ Part 2 --- Country Catalogue
 #. Have a method called ``numberCountriesOnContinent`` that takes a continent name as a parameter and returns the number of ``Country`` objects on that continent
 
 #. Write a method called ``filterCountriesByContinent`` that takes a continent name as a parameter and returns a ``Country`` array containing only the countries on the specified continent
+    * You may find ``numberCountriesOnContinent`` useful here
 
 #. A method called ``findCountryLargestPopulation`` that returns the ``Country`` with the largest population in the ``catalogue``
 
 #. Have a method called ``findMostPopulousContinent`` that returns the name of the continent with the largest total population based on the countries in the ``catalogue``
 
 #. Write the ``toString`` method to return a ``String`` with each ``Country`` object's details on a separate line
+    * The ``Country`` class' ``toString`` will be useful for getting the object's details
+    * Below is an example
+
+            ``China, Asia, 1339190000, 9596960.0``
+
+            ``United States of America, North America, 309975000, 9629091.0``
+
+            ``Brazil, South America, 193364000, 8511965.0``
+
 
 #. Write a ``saveCatalogue`` method to save the string representing the ``CountryCatalogue`` to a specified file
+    * The file name will be passed as a parameter
+    * ``toString`` will be of use here
 
 
 

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -58,13 +58,11 @@ country ``name`` (string), ``population`` (int), ``area`` (double), and ``contin
 
 3. Write a setter method for the country's ``population``. This will be the only setter we need as the other fields do not typically change all too often for countries.
 
-4. Write an ``equals`` method to compare two (2) country objects. Simply check if all fields are the same --- for our purposes, if they are, then we'll say they are equal.
-
-5. Write a ``toString`` method that returns a string containing the country ``name``, ``continent``, ``population``, and ``area``, all seperated by commas and a space. See the below example
+4. Write a ``toString`` method that returns a string containing the country ``name``, ``continent``, ``population``, and ``area``, all seperated by commas and a space. See the below example
 
     ``"Canada, North America, 34207000, 9976140.00"``
 
-6. Write some simple testing code to ensure the object is working as you expect. Try creating instances. Getting their fields, setting the population, etc. --- just test each method. This testing code is not to be submitted.
+5. Write some simple testing code to ensure the object is working as you expect. Try creating instances. Getting their fields, setting the population, etc. --- just test each method. This testing code is not to be submitted.
 
 
 Part 2 --- Country Catalogue

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -69,6 +69,14 @@ Part 2 --- Country Catalogue
 ============================
 
 
+#. Create a method called ``setPopulation`` that takes a name of a country and a new population value for that country as parameters
+
+#. Have a method called ``numberCountriesOnContinent`` that takes a continent name as a parameter and returns the number of ``Country`` objects on that continent
+
+#. Write a method called ``filterCountriesByContinent`` that takes a continent name as a parameter and returns a ``Country`` array containing only the countries on the specified continent
+
+
+
 Part 3 --- Testing
 ==================
 


### PR DESCRIPTION
### Related Issues or PRs
Follows #414 

### What
Add more questions/functionality for/to the class

### Where
This will follow the first half of questions in #414. Note the numbering will start at `1` in this series of questions as a consequence of using `#`. Once combined with #414, the numbering will be correct. 

### Testing
Built local

### Additional Notes
1. I was not a huge fan of the spacing for the `CountryCatalogue`'s `toString` example. I tried to make it a code block, but then it started emphazising things weird, so I stuck with the verbatum/codelike text. 
2. I originally wanted to have ``filterCountriesByContinent`` return a new ``CountryCatalogue``, but thought that perhaps that would be a _little much_ at this stage --- "wait, objects can create instances of themselves? :exploding_head:" Changing this to be a new ``CountryCatalogue`` would almost be simpler, but it would require another constructor. Either way, the array version has them keeping track of seperate indicies for the filtered catalogue and the catalogue. 