### PR TITLE
:bomb: Asn1 Remove `equals`, `hashCode` and map stuff from `CountryCatalogue`

### DIFF
--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -114,6 +114,9 @@ There will also be a static constant
 #. A method called ``findCountryLargestPopulation`` that returns the ``Country`` with the largest population in the ``catalogue``
 
 #. Have a method called ``findMostPopulousContinent`` that returns the name of the continent with the largest total population based on the countries in the ``catalogue``
+    * I strongly recommend making use of a *hash map* to keep track of continent populations
+    * A map is the same idea as a dictionary from Python
+    * `How does one use a hash map? <https://www.google.com/search?q=java+hashmap&oq=java+hashmap>`_
 
 #. Write the ``toString`` method to return a ``String`` with each ``Country`` object's details on a separate line
     * The ``Country`` class' ``toString`` will be useful for getting the object's details

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -75,13 +75,10 @@ Part 2 --- Country Catalogue
 
 The ``CountryCatalogue`` class will be a collection of ``Country`` objects.
 
-There will be three fields
+There will be two fields
 
     * ``size``, an int to keep track of the number of countries in the catalogue
     * ``catalogue``, an array of ``Country`` objects
-    * ``countryContinent``, a *hash map* to keep track of the country/continent relationships
-        * A map is the same idea as a dictionary from Python
-        * `How does one use a hash map? <https://www.google.com/search?q=java+hashmap&oq=java+hashmap>`_
 
 There will also be a static constant
 
@@ -89,19 +86,17 @@ There will also be a static constant
         * This will be used as a starting size for the ``catalogue`` array
 
 #. Create a constructor that will setup and create an empty catalogue of countries
-    * This constructor should set the ``size``, ``catalogue``, and ``countryContinent`` fields appropriately
+    * This constructor should set the ``size`` and ``catalogue`` fields appropriately
 
 #. Write an ``add`` method that will take all the information needed to create a new ``Country`` object (name, population, area, continent) as parameters and add it to the ``catalogue``
     * It is possible that our ``catalogue`` array runs out of space, so we may need to ``expandCapacity``
     * Be sure to properly keep track of the number of countries in the catalogue
-    * Do not forget about the ``countryContinent`` map
 
 #. Write a private method called ``expandCapacity`` that will double the size of the ``Country`` array used for holding reference to the countries
     * Always double the size of the array
 
 #. Create a ``remove`` method that removes a ``Country`` object from the ``catalogue`` based on the parameterized country name
     * Remember to keep track of the size
-    * Do not worry about eliminating anything from the ``countryContinent`` map
     * Be careful about how you are comparing strings
     * If the country is not in the ``catalogue``, everything should be left alone
 

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -63,10 +63,6 @@ country ``name`` (string), ``population`` (int), ``area`` (double), and ``contin
 
     ``"Canada, North America, 34207000, 9976140.00"``
 
-#. Write an ``equals`` method
-    * We will want to get an ``Object`` as a parameter, **not** simply a ``Country`` --- :doc:`follow topic 3's aside on equals </topic3-equals>`
-    * Simply check if all fields are the same --- for our purposes, if they are, then we'll say they are equal
-
 #. You will notice an existing method called ``hashCode`` within the ``Country`` class that returns an integer
     * This was briefly discussed last semester when learning about dictionaries
     * This method turns an object into an integer (*ideally* unique) for the purposes of hashing

--- a/src/site/asn1.rst
+++ b/src/site/asn1.rst
@@ -63,12 +63,6 @@ country ``name`` (string), ``population`` (int), ``area`` (double), and ``contin
 
     ``"Canada, North America, 34207000, 9976140.00"``
 
-#. You will notice an existing method called ``hashCode`` within the ``Country`` class that returns an integer
-    * This was briefly discussed last semester when learning about dictionaries
-    * This method turns an object into an integer (*ideally* unique) for the purposes of hashing
-    * Do not worry about understanding this completely at this stage
-        * It's here because it is needed for the hash map in the ``CountryCatalogue`` class discussed below
-        * `If you are interested, checkout the relevant wiki article <https://en.wikipedia.org/wiki/Hash_function>`_
 
 #. Write some simple testing code to ensure the object is working as you expect
     * Try creating instances


### PR DESCRIPTION
### Related Issues or PRs
After a realization from #418 

### What
Remove the `equals` and `hashCode` methods from the `Country` class
Remove the map field from the `CountryCatalogue`
Add a note about maps for `findMostPopulousContinent` since it makes life easy

### Why
None of it is needed and it simplifies stuff

### Testing
Built local