### PR TITLE
:bug: 🔭 Topic3 Remove Capacity

### DIFF
--- a/src/site/topic3.rst
+++ b/src/site/topic3.rst
@@ -549,7 +549,7 @@ Adding Friends
        :align: center
 
 * The ``expandCapacity`` method gets called automatically by the ``add`` method if our array has run out of space
-* If the array had enough room, ``expand capacity`` is never called
+* If the array had enough room, ``expandCapacity`` is never called
 * Either way, when we add the ``newFriend`` to our array, we are now guaranteed to have room
 
 * You will also see that the ``expandCapacity`` method is ``private``

--- a/src/site/topic3.rst
+++ b/src/site/topic3.rst
@@ -442,7 +442,6 @@ Setting Fields and Writing the Constructor
 
         static final int DEFAULT_CAPACITY = 10;
 
-        private int capacity;
         private int friendCount;
         private Friend[] friends;
 


### PR DESCRIPTION
### Related Issues or PRs
Closes #433 

### What
Remove the `capacity` field from the `ContactList` discussion in topic3

### Why
Not needed. This was an artifact of copy/paste from cpp.

### Additional Notes
Also snuck in a fix `expand capacity` -> `expandCapacity` in topic. 