### PR TITLE
🐛 Fixed typos in topic 3 and topic 4

### DIFF
--- a/src/site/topic3-builder.rst
+++ b/src/site/topic3-builder.rst
@@ -3,7 +3,7 @@ Topic #3 Aside --- Builder
 **************************
 
 * Due to how Strings work, it ends up being wasteful to append to strings
-    * They're *immutable**
+    * They're *immutable*
         * Can't be changed once created
     * Every time we append, we actually create a new string object
 

--- a/src/site/topic4.rst
+++ b/src/site/topic4.rst
@@ -11,7 +11,7 @@ Topic #4 --- Collections
 Collections and ADTs
 ====================
 
-* A collection is a group o *things* that we want to treat as a special conceptual unit
+* A collection is a group of *things* that we want to treat as a special conceptual unit
     * A contact list
     * A stamp collection
 


### PR DESCRIPTION
### Related Issues or PRs
Resolves #445
Resolves #446 

### What
Typo fixes in topic 3 and topic 4

### Why
Better readability

### Where
Topic 3 - Aside - Builder (topic3-builder.html)
The second bulletin from the top of the page. The word immutable with the extra asterisk.

Topic # 4 - Collections (topic4.html) under the header "Collections and ADTs". The first bulletin point.

### How
Remove the extra asterisk around the word "immutable"
Fix the typo "o" to "of"