### PR TITLE
:new: Asn2 Include empty `solve` in `DfsMazeSolver`

### DIFF
--- a/src/site/data/Assignment2/src/DfsMazeSolver.java
+++ b/src/site/data/Assignment2/src/DfsMazeSolver.java
@@ -2,5 +2,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class DfsMazeSolver implements MazeSolver {
-
+    
+    @Override
+    public Set<Cell> solve(Maze maze) {
+        return null;
+    }
 }

--- a/src/site/data/Assignment2/src/DfsMazeSolver.java
+++ b/src/site/data/Assignment2/src/DfsMazeSolver.java
@@ -2,8 +2,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class DfsMazeSolver implements MazeSolver {
-    
-    @Override
+
     public Set<Cell> solve(Maze maze) {
         return null;
     }


### PR DESCRIPTION
### Related Issues or PRs
As discussed in #466 

### What
Include an empty `solve` method in the `DfsMazeSolver`.

### Why
1. It will eliminate the error of not implementing the `MazeSolver` interface. 
2. It will make part 2 of the assignment a little easier. 
3.

### Additional Notes
I checked, and this does not create inconsistencies in the asn2.rst file