### PR TITLE
:bug: `ArrayStackEqualsTest` Include Missing Capacity

### DIFF
--- a/src/test/java/ArrayStackEqualsTest.java
+++ b/src/test/java/ArrayStackEqualsTest.java
@@ -20,7 +20,7 @@ class ArrayStackEqualsTest {
         ArrayStack<Integer> gReverseDefault = new ArrayStack<>();
         ArrayStack<Integer> gReverseCapacity = new ArrayStack<>(10);
         ArrayStack<Character> gTypeDefault = new ArrayStack<>();
-        ArrayStack<Character> gTypeCapacity = new ArrayStack<>();
+        ArrayStack<Character> gTypeCapacity = new ArrayStack<>(10);
 
         for (int i = 0; i < 6; i++) {
             gManyOneDefaultA.push(i);


### PR DESCRIPTION
### What
Throw in the capacity for `gTypeCapacity`

### Why
It should've been there. 

### Additional Notes
Will update in the other repo too. 