### PR TITLE
🆕 Add Download Links to the Thorough Tests

### DIFF
--- a/src/site/topic11.rst
+++ b/src/site/topic11.rst
@@ -200,7 +200,7 @@ For next time
 
 * Download and play with the :download:`LinkedQueue <../main/java/LinkedQueue.java>` code
 * Download and run the :download:`LinkedQueueTest <../test/java/LinkedQueueTest.java>` tests
-    * Or the more thorough tests found in :download:`LinkedQueueThoroughTest <../test/java/LinkedQueueTest.java>`
+    * Or the more thorough tests found in :download:`LinkedQueueThoroughTest <../test/java/LinkedQueueThoroughTest.java>`
 * Read Chapter 5 Section 6
     * 6 pages
 

--- a/src/site/topic11.rst
+++ b/src/site/topic11.rst
@@ -200,6 +200,7 @@ For next time
 
 * Download and play with the :download:`LinkedQueue <../main/java/LinkedQueue.java>` code
 * Download and run the :download:`LinkedQueueTest <../test/java/LinkedQueueTest.java>` tests
+    * Or the more thorough tests found in :download:`LinkedQueueThoroughTest <../test/java/LinkedQueueTest.java>`
 * Read Chapter 5 Section 6
     * 6 pages
 

--- a/src/site/topic12.rst
+++ b/src/site/topic12.rst
@@ -399,6 +399,7 @@ For next time
 
 * Download and play with the :download:`ArrayQueue <../main/java/ArrayQueue.java>` code
 * Download and run the :download:`ArrayQueueTest <../test/java/ArrayQueueTest.java>` tests
+    * Or the more thorough tests found in :download:`ArrayQueueThoroughTest <../test/java/ArrayQueueTest.java>`
 * Read Chapter 5 Section 7
     * 7 pages
 

--- a/src/site/topic12.rst
+++ b/src/site/topic12.rst
@@ -399,7 +399,7 @@ For next time
 
 * Download and play with the :download:`ArrayQueue <../main/java/ArrayQueue.java>` code
 * Download and run the :download:`ArrayQueueTest <../test/java/ArrayQueueTest.java>` tests
-    * Or the more thorough tests found in :download:`ArrayQueueThoroughTest <../test/java/ArrayQueueTest.java>`
+    * Or the more thorough tests found in :download:`ArrayQueueThoroughTest <../test/java/ArrayQueueThoroughTest.java>`
 * Read Chapter 5 Section 7
     * 7 pages
 

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -269,7 +269,7 @@ For next time
 * Download and test the :download:`Stack <../main/java/Stack.java>` and  :download:`ArrayStack <../main/java/ArrayStack.java>` code
 * :doc:`Check out the aside on testing </topic6-testing>`
 * Download and run the :download:`ArrayStackTest <../test/java/ArrayStackTest.java>` tests
-    * Or the more thorough tests found in :download:`LinkedArrayThoroughTest <../test/java/ArrayStackThoroughTest.java>`
+    * Or the more thorough tests found in :download:`ArrayStackThoroughTest <../test/java/ArrayStackThoroughTest.java>`
 * Finish reading Chapter 3
     * 16 pages
 

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -268,6 +268,8 @@ For next time
 
 * Download and test the :download:`Stack <../main/java/Stack.java>` and  :download:`ArrayStack <../main/java/ArrayStack.java>` code
 * :doc:`Check out the aside on testing </topic6-testing>`
+* Download and run the :download:`ArrayStackTest <../test/java/ArrayStackTest.java>` tests
+    * Or the more thorough tests found in :download:`LinkedArrayThoroughTest <../test/java/ArrayStackTest.java>`
 * Finish reading Chapter 3
     * 16 pages
 

--- a/src/site/topic6.rst
+++ b/src/site/topic6.rst
@@ -269,7 +269,7 @@ For next time
 * Download and test the :download:`Stack <../main/java/Stack.java>` and  :download:`ArrayStack <../main/java/ArrayStack.java>` code
 * :doc:`Check out the aside on testing </topic6-testing>`
 * Download and run the :download:`ArrayStackTest <../test/java/ArrayStackTest.java>` tests
-    * Or the more thorough tests found in :download:`LinkedArrayThoroughTest <../test/java/ArrayStackTest.java>`
+    * Or the more thorough tests found in :download:`LinkedArrayThoroughTest <../test/java/ArrayStackThoroughTest.java>`
 * Finish reading Chapter 3
     * 16 pages
 

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -281,6 +281,7 @@ For next time
 * Look into the :doc:`nested node class aside. </topic8-nested>`
 * Download and play with the :download:`LinkedStack <../main/java/LinkedStack.java>` code
 * Download and run the :download:`LinkedStackTest <../test/java/LinkedStackTest.java>` tests
+    * Or the more thorough tests found in :download:`LinkedStackThoroughTest <../test/java/LinkedStackTest.java>`
 * Read Chapter 4 Section 6
     * 13 pages
 

--- a/src/site/topic8.rst
+++ b/src/site/topic8.rst
@@ -281,7 +281,7 @@ For next time
 * Look into the :doc:`nested node class aside. </topic8-nested>`
 * Download and play with the :download:`LinkedStack <../main/java/LinkedStack.java>` code
 * Download and run the :download:`LinkedStackTest <../test/java/LinkedStackTest.java>` tests
-    * Or the more thorough tests found in :download:`LinkedStackThoroughTest <../test/java/LinkedStackTest.java>`
+    * Or the more thorough tests found in :download:`LinkedStackThoroughTest <../test/java/LinkedStackThoroughTest.java>`
 * Read Chapter 4 Section 6
     * 13 pages
 


### PR DESCRIPTION
### What
Add download links to the thorough versions of the tests for the stacks and queues. 

### Why
For their reference. I like the idea of keeping the simpler ones in as a starting point for them. 

### Where
End of each topic's respective page. Note that the `ArrayStack` had no download to the tests originally since it was included in the aside, but I opted to add download links to the main page too. 