### PR TITLE
🆕 Asn2 Add warning about adding JUnit

### DIFF
--- a/src/site/asn2.rst
+++ b/src/site/asn2.rst
@@ -47,6 +47,11 @@ You are provided with:
     When you open the project, IntelliJ may notify you about a missing JDK. If this is the case, simply select the
     download link in the notification.
 
+.. warning::
+
+    Java may say that it cannot find JUnit. If this happens, you need to add JUnit to the project. Simply follow the
+    first few steps of :doc:`Topic 6's aside on testing </topic6-testing>`.
+
 
 Part 0 --- Read the Assignment
 ==============================


### PR DESCRIPTION
### What
Add a warning about needing to add JUnit. 

### Why
Some students are finding that they still need to tell IntelliJ to add JUnit for them. 