### PR TITLE
:bug: Asn2 Fix Renfererererer test class name

### DIFF
--- a/src/site/asn2.rst
+++ b/src/site/asn2.rst
@@ -31,7 +31,7 @@ You are provided with:
 * An ``ArrayStack`` class with ``ArrayStackTest`` unit tests
 * A ``Cell`` class with ``CellTest`` unit tests
 * A ``Maze`` class with ``MazeTest`` unit tests
-* A ``MazeRenderer`` class with ``MazeRenderer`` unit tests
+* A ``MazeRenderer`` class with ``MazeRendererTest`` unit tests
 * Two exceptions: ``LocationNotInMazeException`` and ``MazeEndpointsException``
 * A ``MazeSolver`` interface
 * A nearly empty ``DfsMazeSolver`` with a complete ``DfsMazeSolverTest``


### PR DESCRIPTION
### What
`MazeRenderer` -> `MazeRendererTest`

### Why
It's wrong

### Additional Notes
This was addressed for asn3 already in #491 