### PR TITLE
🆕 Asn4 Add Test Details Back

### DIFF
--- a/src/site/data/Assignment4/test/HuffInternalTest.java
+++ b/src/site/data/Assignment4/test/HuffInternalTest.java
@@ -3,6 +3,38 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class HuffInternalTest {
+    private static final HuffmanInternal LEFT_CHILD_INTERNAL = new HuffmanInternal(10, null, null);
+    private static final HuffmanLeaf RIGHT_CHILD_LEAF = new HuffmanLeaf(10, 'a');
 
+    private HuffmanInternal classUnderTest;
 
+    @Test
+    void getWeight_onlyUseCase_returnsWeight() {
+
+    }
+
+    @Test
+    void getLeft_leftChildInternal_returnsLeftChildInternalNode() {
+
+    }
+
+    @Test
+    void getRight_rightChildLeaf_returnsRightChildLeafNode() {
+
+    }
+
+    @Test
+    void getLeft_noLeftChild_returnsNull() {
+
+    }
+
+    @Test
+    void getRight_noRightChild_returnsNull() {
+
+    }
+
+    @Test
+    void toString_onlyUseCase_returnsString() {
+
+    }
 }

--- a/src/site/data/Assignment4/test/HuffLeafTest.java
+++ b/src/site/data/Assignment4/test/HuffLeafTest.java
@@ -3,7 +3,26 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HuffLeafTest {
+    
+    private HuffmanLeaf classUnderTest;
 
+    @Test
+    void getWeight_onlyUseCase_returnsWeight() {
 
+    }
 
+    @Test
+    void getCharacter_lowerCaseCharacter_returnsLowerCaseCharacter() {
+
+    }
+
+    @Test
+    void getCharacter_upperCaseCharacter_returnsLowerCaseCharacter() {
+
+    }
+
+    @Test
+    void toString_onlyUseCase_returnsString() {
+
+    }
 }

--- a/src/site/data/Assignment4/test/HuffNodeComparatorTest.java
+++ b/src/site/data/Assignment4/test/HuffNodeComparatorTest.java
@@ -26,5 +26,39 @@ public class HuffNodeComparatorTest {
 
     private HuffmanNodeComparator classUnderTest;
 
+    @BeforeEach
+    void createComparator() {
+        classUnderTest = new HuffmanNodeComparator();
+    }
 
+    @Test
+    void compare_unsortedList_sortsList() {
+        List<HuffmanNode> sorted = List.of(
+                SMALLER_WEIGHT_LEAF,
+                SMALLER_WEIGHT_INTERNAL,
+                SMALLER_ASCII_LEAF,
+                TEST_LEAF,
+                LARGER_ASCII_LEAF,
+                TEST_INTERNAL,
+                LARGER_WEIGHT_LEAF,
+                LARGER_WEIGHT_INTERNAL
+        );
+        List<HuffmanNode> unsorted = new ArrayList<>(sorted);
+        Collections.shuffle(unsorted);
+        unsorted.sort(classUnderTest);
+        assertEquals(sorted, unsorted);
+    }
+
+    @Test
+    void compare_vsEqualAsciiLeaf_returnsZero() {
+        // This should never happen in practice
+        int compared = classUnderTest.compare(TEST_LEAF, EQUAL_ASCII_LEAF);
+        assertEquals(0, compared);
+    }
+
+    @Test
+    void compare_vsEqualWeightInternal_returnsZero() {
+        int compared = classUnderTest.compare(TEST_INTERNAL, EQUAL_WEIGHT_INTERNAL);
+        assertEquals(0, compared);
+    }
 }

--- a/src/site/data/Assignment4/test/HuffmanCodeTest.java
+++ b/src/site/data/Assignment4/test/HuffmanCodeTest.java
@@ -54,5 +54,66 @@ public class HuffmanCodeTest {
 
     private HuffmanCode classUnderTest;
 
+    @Test
+    void fromString_emptyString_throwsIllegalArgumentException() {
 
+    }
+
+    @Nested
+    class SimpleString {
+
+        static Stream<String> sourceKeysSimple() {
+            return SIMPLE_PREFIX.keySet().stream();
+        }
+
+        @BeforeEach
+        void create_HuffmanCode() {
+
+        }
+
+        @ParameterizedTest
+        @MethodSource("sourceKeysSimple")
+        void encode_specificLetter_returnsLetterCode(String letter) {
+
+        }
+
+        @Test
+        void encode_exampleString_returnsEncodedString() {
+
+        }
+
+        @Test
+        void decode_encodedString_returnsOriginalString() {
+
+        }
+    }
+
+    @Nested
+    class WikiString {
+
+        static Stream<String> sourceKeysWiki() {
+            return WIKI_PREFIX.keySet().stream();
+        }
+
+        @BeforeEach
+        void create_HuffmanCode() {
+            classUnderTest = HuffmanCode.fromString(WIKI_SEED);
+        }
+
+        @ParameterizedTest
+        @MethodSource("sourceKeysWiki")
+        void encode_specificLetter_returnsLetterCode(String letter) {
+
+        }
+
+        @Test
+        void encode_exampleString_returnsEncodedString() {
+
+        }
+
+        @Test
+        void fromFile_encoding_sameAsFromStringEncoding() {
+
+        }
+    }
 }


### PR DESCRIPTION
### What
- Put the complete `HuffNodeComparatorTest` back
- Put the methods back in all other test classes, but leave them empty

### Why
Since the comparator is a huge integral part of the assignment, I figure this will help a lot. 

I think having them do them all on their own is a bit of a jump. Depending on how this year goes, this may change. Having the skeleton of the methods should help a lot while still having them think about them. 