### PR TITLE
🎓 Asn4 Add Link to index

### DIFF
--- a/src/site/index.rst
+++ b/src/site/index.rst
@@ -142,6 +142,7 @@ Assignments
     asn1
     asn2
     asn3
+    asn4
 
 
 Course Outline


### PR DESCRIPTION
### What
Add asn4 to the index page. 

### Why
So people can get to the page easy. 