### PR TITLE
💄 Lab 5 Change `T` -> `Integer` in first method

### DIFF
--- a/src/site/lab5.rst
+++ b/src/site/lab5.rst
@@ -46,7 +46,7 @@ Create the Linked Structure
 
     .. code-block:: java
 
-        public static <T> Node<T> makeLinkedStructure() {
+        public static Node<Integer> makeLinkedStructure() {
             // Stuff
         }
 


### PR DESCRIPTION
### Related Issues or PRs
Closes #523 

### What
Make the method creating the structure not generic. 

### Why
It ends up just confusing them because the way it is requires them to cast it as `T`, which is weird. 

### Additional Notes
Wasn't planning on fixing it now, but whatevz. 
