### PR TITLE
:lipstick: Topic12 `expandCapacity` Aside Reorder

### DIFF
--- a/src/site/topic12-expand.rst
+++ b/src/site/topic12-expand.rst
@@ -35,7 +35,7 @@ ArrayQueue
 
 * Note that ``front`` is ``2`` and ``rear`` is ``2``
 * The order of the elements' indices in the queue from first to last is ``2``, ``3``, ``0``, ``1``
-    * Our ``ArrayQueue`` manages this ordering with our index update rule of ``rear = (rear + `) % queue.length``
+    * Our ``ArrayQueue`` manages this ordering with our index update rule of ``rear = (rear + 1) % queue.length``
 * Even after the ``expandCapacity`` there is no room for any new element in index ``2``
 
 * Imagine we just ``enqueue`` and add the element in the first free index (index ``4``)

--- a/src/site/topic12-expand.rst
+++ b/src/site/topic12-expand.rst
@@ -9,16 +9,22 @@ ArrayStack
    :width: 500 px
    :align: center
 
-* With the ``ArrayStack``, this was not an issue since the adding and removing only happened from one end of the array
+* With the ``ArrayStack``, the adding and removing only happened from one end of the array
     * The array will always be contiguous from the bottom of the stack (index ``0``) to the top
-* The added complexity of ``expandCapacity`` for the ``ArrayQueue`` is caused by the circle array idea
-    * The circle array idea allows for the information to not be contiguous in the underlying linear array
 
-* Note that for ideas #1 and #2 for the ``ArrayQueue``, this added complexity is not an issue since the data will always be contiguous
+* If ``expandCapacity`` was ever needed, all the data would be copied to the new array such that each element would be in the same index
+    * The element at index 1 in the old array would be in index 1 of the new array
+    * The element at index 2 in the old array would be in index 2 of the new array
+    * ...
+
+* For ideas #1 and #2 of the ``ArrayQueue``, an ``expandCapacity`` like the one used for the ``arrayStack`` would work just fine
 
 
 ArrayQueue
 ==========
+
+* The added complexity of ``expandCapacity`` for idea #3 of the ``ArrayQueue`` is caused by the circle array idea
+    * The circle array idea allows for the information to not be contiguous in the underlying linear array
 
 * Consider the scenario where we attempt to use the ``expandCapacity`` we used for the ``ArrayStack``
     * Where we simply double the size of the array and copy the contents over

--- a/src/site/topic12-expand.rst
+++ b/src/site/topic12-expand.rst
@@ -2,6 +2,23 @@
 Topic #12 Aside --- expandCapacity
 **********************************
 
+ArrayStack
+==========
+
+.. image:: img/arraystack0.png
+   :width: 500 px
+   :align: center
+
+* With the ``ArrayStack``, this was not an issue since the adding and removing only happened from one end of the array
+    * The array will always be contiguous from the bottom of the stack (index ``0``) to the top
+* The added complexity of ``expandCapacity`` for the ``ArrayQueue`` is caused by the circle array idea
+    * The circle array idea allows for the information to not be contiguous in the underlying linear array
+
+* Note that for ideas #1 and #2 for the ``ArrayQueue``, this added complexity is not an issue since the data will always be contiguous
+
+
+ArrayQueue
+==========
 
 * Consider the scenario where we attempt to use the ``expandCapacity`` we used for the ``ArrayStack``
     * Where we simply double the size of the array and copy the contents over
@@ -29,16 +46,3 @@ Topic #12 Aside --- expandCapacity
 * This ordering seems rather chaotic and would require more complex bookkeeping
 
 
-ArrayStack
-==========
-
-.. image:: img/arraystack0.png
-   :width: 500 px
-   :align: center
-
-* With the ``ArrayStack``, this was not an issue since the adding and removing only happened from one end of the array
-    * The array will always be contiguous from the bottom of the stack (index ``0``) to the top
-* The added complexity of ``expandCapacity`` for the ``ArrayQueue`` is caused by the circle array idea
-    * The circle array idea allows for the information to not be contiguous in the underlying linear array
-
-* Note that for ideas #1 and #2 for the ``ArrayQueue``, this added complexity is not an issue since the data will always be contiguous

--- a/src/site/topic12-expand.rst
+++ b/src/site/topic12-expand.rst
@@ -13,8 +13,9 @@ ArrayStack
     * The array will always be contiguous from the bottom of the stack (index ``0``) to the top
 
 * If ``expandCapacity`` was ever needed, all the data would be copied to the new array such that each element would be in the same index
-    * The element at index 1 in the old array would be in index 1 of the new array
-    * The element at index 2 in the old array would be in index 2 of the new array
+    * The element at index ``0`` in the old array would be in index ``0`` of the new array
+    * The element at index ``1`` in the old array would be in index ``1`` of the new array
+    * The element at index ``2`` in the old array would be in index ``2`` of the new array
     * ...
 
 * For ideas #1 and #2 of the ``ArrayQueue``, an ``expandCapacity`` like the one used for the ``arrayStack`` would work just fine


### PR DESCRIPTION
### Related Issues or PRs
Closes #153 

### What
Reorder and massage the content in the aside to introduce the simpler `arrayStack` `expandCapacity` that they are already used to. 

### Why
As @twentylemon suggests in #156, it's probably better to start with what they know, not the other way around. 