### PR TITLE
🐛 Stack -> Queue

### DIFF
--- a/src/test/java/LinkedQueueThoroughTest.java
+++ b/src/test/java/LinkedQueueThoroughTest.java
@@ -83,7 +83,7 @@ public class LinkedQueueThoroughTest {
             }
 
             @Test
-            void dequeue_singleton_emptyStack() {
+            void dequeue_singleton_emptyQueue() {
                 classUnderTest.dequeue();
                 assertEquals(new LinkedQueue<>(), classUnderTest);
             }


### PR DESCRIPTION
### What
Rename test method to use queue instead of stack

### Why
Because it's a queue, not a stack. 