### PR TITLE
:bug: Topic12 Remove Extra Backticks

### DIFF
--- a/src/site/topic12.rst
+++ b/src/site/topic12.rst
@@ -71,7 +71,7 @@ Idea #2
    :width: 500 px
    :align: center
 
-* ``dequeue`` always happens at index ``front````
+* ``dequeue`` always happens at index ``front``
 * Increment ``front``
 
 


### PR DESCRIPTION
### What
Remove extra backticks. 

### Why
There was four \`\`\`\` when there should have been two. This caused the text to render incorrectly. 