### PR TITLE
:bug::poop: Cpp Reference Remove extra space

### DIFF
--- a/src/site/cpp-references.rst
+++ b/src/site/cpp-references.rst
@@ -42,7 +42,7 @@ How To Use Them
     * Create an ``int`` variable ``a``
     * Assign ``6`` to ``a``
     * Create a reference to an ``int`` called ``b`` and assign it to ``a``
-    * Change the contents of ``a``/ ``b`` through ``b``
+    * Change the contents of ``a``/``b`` through ``b``
 
 
 .. code-block:: cpp


### PR DESCRIPTION
### What
Remove an extra space between `a` and `b`

### Additional Notes
I expected more changes, but I guess this is it. 
