### PR TITLE
🐛 : typo in Topic16 (Example to Instance)

### DIFF
--- a/src/site/topic16.rst
+++ b/src/site/topic16.rst
@@ -57,7 +57,7 @@ Iterator Interface
 * In the end, if we use an iterator, we do not care what the underlying container is for the data since, no matter what it is, we get each element with ``next`` and check if there are more elements with ``hasNext``
 
 
-* For example, here is an example of using an iterator to iterate over an arbitrary iterable thing of type ``T``
+* For instance, here is an example of using an iterator to iterate over an arbitrary iterable thing of type ``T``
 
 .. code-block:: Java
     :linenos:


### PR DESCRIPTION
change "For example, here is an example of using an iterator to iterate over an arbitrary iterable thing of type ``T``" to "For instance, here is an example of using an iterator to iterate over an arbitrary iterable thing of type ``T``"

:new: :bomb: :mortar_board: :memo: :robot: :lipstick: :bug: :telescope: :art: Add relevant emojis to title. [See style guide.](https://github.com/jameshughes89/cs102/blob/main/CONTRIBUTING.md#style-guidelines).


### Related Issues or PRs
If applicable, replace this text with links to issues and other PRs. [Link with a keyword if you can.](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue)

### What
Typo in topic16 changing "For example, here is an example" to "For instance, here is an example"

### Why
Because grammar is a nice thing

### Where
In topic 16 under Iterator Interface

### How
In a way that fixes the typo

