### PR TITLE
:lipstick: Cpp Arrays Note Move Point to Sentence

### DIFF
--- a/src/site/cpp-arrays.rst
+++ b/src/site/cpp-arrays.rst
@@ -15,9 +15,7 @@ C++ Lessons #4 --- Arrays
 .. note::
 
     Here we will go over the basics of arrays in C/C++; however, in practice you will likely be making use of C++'s
-    standard library's ``std::vector``.
-
-        * `std::vector <https://en.cppreference.com/w/cpp/container/vector/>`_
+    standard library's `std::vector <https://en.cppreference.com/w/cpp/container/vector/>`_.
 
 
 Static Arrays


### PR DESCRIPTION
### What
Move the point to the sentence. 

### Why
It will look better this way. 

### Additional Notes
It was a point because I mentioned this and `std::array`` too. Now the arrays are not mentioned. 
