### PR TITLE
Update Method Name

### DIFF
--- a/src/site/asn3.rst
+++ b/src/site/asn3.rst
@@ -132,7 +132,7 @@ In order to complete the ``LinkedPriorityQueue``, you will need write a construc
     * ``void enqueue(T element, int priority)``
     * ``void enqueue(T element)``
     * ``T dequeue()``
-    * ``T front()``
+    * ``T first()``
     * ``int size()``
     * ``boolean isEmpty()``
 


### PR DESCRIPTION
### Related Issues or PRs
Issue 573

### What
Change Assignment 3, Part 3, Implementing the class, "T front()" to "T first()"

### Why
In the Queue interface provided for the assignment, T first() is the method required as per the interface, but the assignment description asks for T front()

### Where
In Assignment 3 description for implementing LinkedPriorityQueue

### How
Changing T front() to T first()
