### PR TITLE
🎓 Asn4 Update Due Date

### DIFF
--- a/src/site/asn4.rst
+++ b/src/site/asn4.rst
@@ -3,7 +3,7 @@ Assignment #4: 1100010110111010001110110100111110001001
 *******************************************************
 
 * **Worth**: 10%
-* **DUE**: April 11th 11:55pm; submitted on MOODLE.
+* **UPDATED DUE DATE**: April 14th 11:55pm; submitted on MOODLE.
 
 
 Task


### PR DESCRIPTION
### What
Move due date back to the last day possible. 

### Why
Because I'm nice. 

I also expected to be a _liiiiiitle_ further in the course content. There's no reason they are not able to do it by Monday as is, but this will help nonetheless. 

### Additional Notes
1. The exam will be released the same day at like noon-ish (whatever the uni's date/time is). 
2. The 7 day no penalty will still apply, but will be overwhelmingly discouraged. 
