### PR TITLE
:memo: Add git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
### What
Add git attributes to repo for EOL consistency 

### Why
Consistency 

### Additional Notes
Everything is already just `\n`, so nothing actually changed other than `.gitattributes`.