### PR TITLE
💄 Index, Outline, and Getting Set --- Clean spacing 

### DIFF
--- a/src/site/getting-set/getting-set.rst
+++ b/src/site/getting-set/getting-set.rst
@@ -2,6 +2,7 @@
 Getting set up for CSCI 162
 ***************************
 
+
 Java Development Kit --- Oracle or OpenJDK
 ==========================================
 

--- a/src/site/getting-set/getting-set.rst
+++ b/src/site/getting-set/getting-set.rst
@@ -17,8 +17,10 @@ Either way, make sure you are using JDK version 11 or higher.
 Other JDKs
 ^^^^^^^^^^
 
-There exist other distributions of JDks out there. Two cool ones are `Amazon's Corretto <https://aws.amazon.com/corretto/>`_
-and `Microsoft's OpenJDK <https://www.microsoft.com/openjdk>`_. You don't need these, but I thought I would let you know they exist.
+There exist other distributions of JDks out there. Two cool ones are
+`Amazon's Corretto <https://aws.amazon.com/corretto/>`_
+and `Microsoft's OpenJDK <https://www.microsoft.com/openjdk>`_. You don't need these, but I thought I would let you know
+they exist.
 
 
 Integrated Development Environment
@@ -39,16 +41,16 @@ Officially:
 * We are using the Oracle or OpenJDK
 * We are using IntelliJ
 * Everything must run on the lab computers
-    * Or whatever are "lab computers" these days
 
 
 I've Still Got Issues
 =====================
 
-* If you are unsure about:
-    * Which processor architecture you have
-    * What is a compressed folder vs. an installer
-    * What about if I am using operating system X
-    * etc.
+If you are unsure about:
 
-* `I am confident you can find the answers on my favourite website <https://www.google.ca/>`_
+* Which processor architecture you have
+* What is a compressed folder vs. an installer
+* What about if I am using operating system X
+* etc.
+
+`I am confident you can find the answers on my favourite website <https://www.google.ca/>`_

--- a/src/site/index.rst
+++ b/src/site/index.rst
@@ -20,8 +20,12 @@ GitHub Repo
 
 * The course content is available on `GitHub <https://github.com/jameshughes89/cs102>`_
 * Feel free to submit issues, fork the repo, and submit pull requests
+
    * Follow the guidelines
+
+
 * In other words, feel free to make contributions to the course content
+
    * In fact, I encourage this
 
 
@@ -46,13 +50,17 @@ Office Hours
 `Office Hours Etiquette --- Don't Do This. <https://www.youtube.com/watch?v=lOTyUfOHgas>`_
 
 * **James Hughes** Virtual Only --- See Moodle
+
     * Tuesday, 10am -- 11am
     * Wednesday, 10am -- 11am
     * Friday, 10am -- 11am
 
+
 * **(TAs)** TBD
+
     * **TBD** (tbd at stfx.ca):
-    	* TBD
+
+        * TBD
 
 
 Learning Centre
@@ -64,7 +72,8 @@ Learning Centre
 MSCS Tutorial Nights
 ====================
 
-`The Math, Stats, and CS Society now has a time and location for our free tutorial sessions. <https://www.mystfx.ca/computer-science/csci-tutorials>`_
+The Math, Stats, and CS Society has a time and location for
+`free tutorial sessions. <https://www.mystfx.ca/computer-science/csci-tutorials>`_
 
 
 Getting Started


### PR DESCRIPTION
### What

1. Clean up the spacing of the rst files 
2. Other small just general cleanup

### Why

With the _Read the Docs_ theme, any point that has an immediate sub-point becomes boldfaced. I do not particularly like this. 

### Where
1. Index
2. Getting set
3. Outline (though, nothing changed here as it was already fine --- noting that it was looked at though)


### How
Adding a new line gap between point and subpoint removes the boldface. 

