### PR TITLE
:technologist: Stack Interface --- Clean up comments

### DIFF
--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -30,12 +30,13 @@ public class ArrayStack<T> implements Stack<T> {
     }
 
     @Override
-    public void push(T element) {
+    public boolean push(T element) {
         if (top == stack.length) {
             expandCapacity();
         }
         stack[top] = element;
         top++;
+        return true;
     }
 
     /**

--- a/src/main/java/LinkedStack.java
+++ b/src/main/java/LinkedStack.java
@@ -12,11 +12,12 @@ public class LinkedStack<T> implements Stack<T> {
     }
 
     @Override
-    public void push(T element) {
+    public boolean push(T element) {
         Node<T> toPush = new Node<T>(element);
         toPush.setNext(top);
         top = toPush;
         size++;
+        return true;
     }
 
     @Override

--- a/src/main/java/Stack.java
+++ b/src/main/java/Stack.java
@@ -1,3 +1,11 @@
+/**
+ * A stack is a linear data structure that has all the action happen from one end referred to as the "top"; all
+ * additions (pushes) and removals (pops) happen from the same end, the "top". This data structure has a "last in,
+ * first out" (LIFO) property --- the last thing that was added to the stack would be the first thing removed from
+ * the stack if a remove were to happen. Adding and removing from anywhere else in the stack is disallowed.
+ *
+ * @param <T> Type of elements that are to be on the stack.
+ */
 public interface Stack<T> {
 
     /**

--- a/src/main/java/Stack.java
+++ b/src/main/java/Stack.java
@@ -9,41 +9,43 @@
 public interface Stack<T> {
 
     /**
-     * Pushes (adds) an item onto the top of the stack. After the method completes
-     * the item added will be the thing on the top of the stack.
+     * Adds (pushes) an element to the stack. The push adds the element to the stack such that it becomes the new
+     * "top" of the stack.
      *
      * @param element The item to be pushed (added) to the stack.
+     * @return True if the element was pushed (added) successfully, false otherwise.
      */
-    void push(T element);
+    boolean push(T element);
 
     /**
-     * Pops (removes) the item from the top of the stack and returns it as the value
-     * of this method. After the method completes, the item after the top will be the
-     * new top if it exists, otherwise the stack will be empty.
+     * Removes (pops) an element from the stack and returns the removed element. The pop removes the element from the
+     * "top" of the stack such that the subsequent element, if it exists, becomes the new "top" of the stack. If no
+     * subsequent element exists, the "top" will be null and the stack will be empty.
      *
-     * @return The item at the top of the stack.
+     * @return The element on the "top" of the stack.
+     * @throws EmptyCollectionException Throw if removing from an empty stack.
      */
     T pop();
 
     /**
-     * Peeks (looks) at the item at the top of the stack and returns it as the value
-     * of this method. After the method completes, the item will still be on the top
-     * of the stack.
+     * Return the element on the "top" of the stack. Peeking leaves the element on the "top" of the stack and leaves
+     * the collection unchanged.
      *
-     * @return The item at the top of the stack.
+     * @return The element on the "top" of the stack.
+     * @throws EmptyCollectionException Throw if peeking from an empty stack.
      */
     T peek();
 
     /**
-     * Tests if the stack is empty and returns a Boolean.
+     * Checks if the stack is currently empty.
      *
-     * @return true if the stack is empty (no items), false otherwise
+     * @return True if the stack is empty, false otherwise.
      */
     boolean isEmpty();
 
     /**
-     * Returns the number of elements in the stack. This method does not handle
-     * the size exceeding Integer.MAX_VALUE.
+     * Returns the number of elements in the stack. This method does not handle the case of size exceeding
+     * Integer.MAX_VALUE.
      *
      * @return The number of elements in the stack.
      */


### PR DESCRIPTION
### What
Clean up the javadoc comments within the stack interface. 

### Why
It's a little better now. 

### Additional Notes
I'm going to try to be consistent going forward with wording (e.g., element vs. item).


`ArrayStack` and `LinkedStack` have been updated to just make them shut up since `push` returns a boolean now. These classes will be updated in some subsequent PR along with their tests. 
