### PR TITLE
💄 StringBuilder Aside --- Clean 🧹 

### DIFF
--- a/src/main/java/ContactList.java
+++ b/src/main/java/ContactList.java
@@ -172,7 +172,7 @@ public class ContactList {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < size(); i++) {
-            builder.append(friends[i].toString());
+            builder.append(friends[i]);
             builder.append("\n");
         }
         return builder.toString();

--- a/src/site/topics/objects-review/builder.rst
+++ b/src/site/topics/objects-review/builder.rst
@@ -1,24 +1,27 @@
-*****************
-Aside --- Builder
-*****************
+************************
+Aside --- String Builder
+************************
 
-* Due to how Strings work, it ends up being wasteful to append to strings
-    * They're *immutable*
-        * Can't be changed once created
-    * Every time we append, we actually create a new string object
+* Due how ``String`` objects work, it ends up being wasteful to continually append to strings
 
-* Instead, the ``StringBuilder`` object can be used to eliminate the extra overhead
+    * ``String`` objects are *immutable*
 
-* Also, there is no need to call ``.toString()`` explicitly since Java will do this for us
-    * This is also true in the example without the ``StringBuilder``
+        * They cannot be changed once they are created
+
+    * When appending, a new ``String`` object needs to be created
+
+
+* An alternative to continually appending to a ``String`` is a ``StringBuilder``, which eliminates the extra overhead
+* See the below example of the ``ContactList`` class' ``toString`` that makes use of a ``StringBuilder``
 
 .. code-block:: java
     :linenos:
+    :emphasize-lines: 4
 
         public String toString() {
             StringBuilder builder = new StringBuilder();
-            for (int i = 0; i < friendCount; ++i) {
-                builder.append(friends[i]);
+            for (int i = 0; i < size(); i++) {
+                builder.append(friends[i].toString());
                 builder.append("\n");
             }
             return builder.toString();

--- a/src/site/topics/objects-review/builder.rst
+++ b/src/site/topics/objects-review/builder.rst
@@ -26,3 +26,9 @@ Aside --- String Builder
             }
             return builder.toString();
         }
+
+.. note::
+
+    On line 4 in the above example, the instances of ``Friend`` objects are having their ``.toString()`` methods called.
+    This is actually unnecessary since the ``StringBuilder`` object's ``append`` method would call this automatically.
+    In other words, line 4 could read ``builder.append(friends[i]);``. 


### PR DESCRIPTION
### What
1. Clean the string builder aside
2. Remove the use of `toString` in the string builder of the `ContactList` class. 

### Why
1. General yearly clean up
2. The main contend does appending to the string. The aside is to show them the builder. Although the `toString` may be more clear to the first time they see it, they _should_ be seeing it for the first time in the aside. Thus, the actual code will not be the first time they see it. 

### Testing
:+1: --- removing `toString `did not kill any tests. 
