### PR TITLE
💣 Stack Interface --- Remove "throws" from @throws line 🔬 

### DIFF
--- a/src/main/java/Stack.java
+++ b/src/main/java/Stack.java
@@ -23,7 +23,7 @@ public interface Stack<T> {
      * subsequent element exists, the "top" will be null and the stack will be empty.
      *
      * @return The element on the "top" of the stack.
-     * @throws EmptyCollectionException Throw if removing from an empty stack.
+     * @throws EmptyCollectionException If removing from an empty stack.
      */
     T pop();
 
@@ -32,7 +32,7 @@ public interface Stack<T> {
      * the collection unchanged.
      *
      * @return The element on the "top" of the stack.
-     * @throws EmptyCollectionException Throw if peeking from an empty stack.
+     * @throws EmptyCollectionException If peeking from an empty stack.
      */
     T peek();
 


### PR DESCRIPTION
### Related Issues or PRs
From #641

### What
Reword `@throws` line to not include "throws" 

### Why
It does sound better. 

### Additional Notes
I went with the "throws" in the line because I looked up an example of how people wrote the line. They had it, so I added it. Regardless though, it does read weird; removing "throws" is superior. 
