### PR TITLE
:telescope: :woman_technologist: Stack Implementations --- Add fifo order test

### DIFF
--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -187,5 +187,24 @@ class ArrayStackTest {
             }
             assertEquals(1000, classUnderTest.size());
         }
+
+        @Test
+        void pop_large_lifoOrdering() {
+            for (int i = 0; i < 1000; i++) {
+                classUnderTest.push(i);
+            }
+            for (int i = 0; i < 500; i++) {
+                classUnderTest.pop();
+            }
+            for (int i = 1000; i < 1500; i++) {
+                classUnderTest.push(i);
+            }
+            for (int i = 1500 - 1; i >= 1000; i--) {
+                assertEquals(i, classUnderTest.pop());
+            }
+            for (int i = 500 - 1; i >= 0; i--) {
+                assertEquals(i, classUnderTest.pop());
+            }
+        }
     }
 }

--- a/src/test/java/LinkedStackTest.java
+++ b/src/test/java/LinkedStackTest.java
@@ -177,4 +177,27 @@ class LinkedStackTest {
             }
         }
     }
+
+    @Nested
+    class WhenLarge {
+
+        @Test
+        void pop_large_lifoOrdering() {
+            for (int i = 0; i < 1000; i++) {
+                classUnderTest.push(i);
+            }
+            for (int i = 0; i < 500; i++) {
+                classUnderTest.pop();
+            }
+            for (int i = 1000; i < 1500; i++) {
+                classUnderTest.push(i);
+            }
+            for (int i = 1500 - 1; i >= 1000; i--) {
+                assertEquals(i, classUnderTest.pop());
+            }
+            for (int i = 500 - 1; i >= 0; i--) {
+                assertEquals(i, classUnderTest.pop());
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Related Issues or PRs
#661 and #660

### What
added a test to check the LIFO ordering of a stack. 

### Why
More explicitly testing ordering. 

### Testing
:+1:

### Additional Notes
As mentioned in #660 and #661, maybe they're silly tests. Will wait on expert opinion. 

