### PR TITLE
:bug: :mortar_board: Array stack topic --- Remove link to removed aside :microscope: 

### DIFF
--- a/src/site/topics/stacks/array-stack.rst
+++ b/src/site/topics/stacks/array-stack.rst
@@ -275,7 +275,6 @@ Exceptional Situations
     :emphasize-lines: 6
 
 
-* The above ``toString`` example uses :doc:`a string builder. </topics/objects-review/builder>`
 * Ideally the top element in the stack would be the left most element in the string representation of a stack
 * However, index ``0`` in the ``stack`` array is the bottom of the stack
 * For this reason, each element is inserted to the front of the string builder


### PR DESCRIPTION
### What
Remove the reference to the builder aside.

### Why
The builder aside was incorporated into the main topic. 

### Testing
:+1: built local, looks good. 

### Additional Notes
Odd that I missed it before as I check for these. 