### PR TITLE
:telescope: :technologist: Array based collections --- `initialCapacity` :microscope: 

### DIFF
--- a/src/main/java/ArrayQueue.java
+++ b/src/main/java/ArrayQueue.java
@@ -24,14 +24,14 @@ public class ArrayQueue<T> implements Queue<T> {
     /**
      * Create an empty ArrayQueue with the specified capacity.
      *
-     * @param capacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array.
      */
     @SuppressWarnings("unchecked")
-    public ArrayQueue(int capacity) {
+    public ArrayQueue(int initialCapacity) {
         front = 0;
         rear = 0;
         size = 0;
-        queue = (T[]) new Object[capacity];
+        queue = (T[]) new Object[initialCapacity];
     }
 
     @Override

--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -23,14 +23,14 @@ public class ArrayStack<T> implements Stack<T> {
     /**
      * Create an empty ArrayStack with the specified capacity.
      *
-     * @param capacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array.
      */
     @SuppressWarnings("unchecked")
-    public ArrayStack(int capacity) {
+    public ArrayStack(int initialCapacity) {
         top = 0;
         // Generic types cannot be instantiated, so an array of type "Object" is created that is then cast to type T.
         // This does generate a compile time warning that is being suppressed with the @ annotation.
-        stack = (T[]) new Object[capacity];
+        stack = (T[]) new Object[initialCapacity];
     }
 
     @Override

--- a/src/main/java/ContactList.java
+++ b/src/main/java/ContactList.java
@@ -25,11 +25,11 @@ public class ContactList {
     /**
      * Create an empty ContactList with the array container's capacity being set to the specified size.
      *
-     * @param capacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array.
      */
-    public ContactList(int capacity) {
+    public ContactList(int initialCapacity) {
         size = 0;
-        friends = new Friend[capacity];
+        friends = new Friend[initialCapacity];
     }
 
     /**


### PR DESCRIPTION
### What
Change the name of the capacity param in the constructors for the array based collections to be `initialCapacity`. As @twentylemon pointed out in the other repo, this is more consistent with the standard library. 

### Why
Consistency

### Testing
:+1: