### PR TITLE
💄 Remove the use of `EmptyCollectionException` 

### DIFF
--- a/src/main/java/ArrayQueue.java
+++ b/src/main/java/ArrayQueue.java
@@ -66,7 +66,7 @@ public class ArrayQueue<T> implements Queue<T> {
     @Override
     public T dequeue() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty queue");
         }
         T returnElement = queue[front];
         front = nextIndex(front);
@@ -77,7 +77,7 @@ public class ArrayQueue<T> implements Queue<T> {
     @Override
     public T first() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty queue");
         }
         return queue[front];
     }

--- a/src/main/java/ArrayQueue.java
+++ b/src/main/java/ArrayQueue.java
@@ -1,3 +1,4 @@
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
@@ -65,7 +66,7 @@ public class ArrayQueue<T> implements Queue<T> {
     @Override
     public T dequeue() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         T returnElement = queue[front];
         front = nextIndex(front);
@@ -76,7 +77,7 @@ public class ArrayQueue<T> implements Queue<T> {
     @Override
     public T first() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         return queue[front];
     }

--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -59,7 +59,7 @@ public class ArrayStack<T> implements Stack<T> {
     @Override
     public T pop() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty stack");
         }
         T returnElement = stack[top - 1];
         stack[top - 1] = null;
@@ -70,7 +70,7 @@ public class ArrayStack<T> implements Stack<T> {
     @Override
     public T peek() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty stack");
         }
         return stack[top - 1];
     }

--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -1,4 +1,5 @@
 import java.util.Arrays;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
@@ -58,7 +59,7 @@ public class ArrayStack<T> implements Stack<T> {
     @Override
     public T pop() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         T returnElement = stack[top - 1];
         stack[top - 1] = null;
@@ -69,7 +70,7 @@ public class ArrayStack<T> implements Stack<T> {
     @Override
     public T peek() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         return stack[top - 1];
     }

--- a/src/main/java/LinkedQueue.java
+++ b/src/main/java/LinkedQueue.java
@@ -42,7 +42,7 @@ public class LinkedQueue<T> implements Queue<T> {
     @Override
     public T dequeue() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty queue");
         }
         T returnElement = front.getData();
         front = front.getNext();
@@ -57,7 +57,7 @@ public class LinkedQueue<T> implements Queue<T> {
     @Override
     public T first() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty queue");
         }
         return front.getData();
     }

--- a/src/main/java/LinkedQueue.java
+++ b/src/main/java/LinkedQueue.java
@@ -1,3 +1,4 @@
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
@@ -41,7 +42,7 @@ public class LinkedQueue<T> implements Queue<T> {
     @Override
     public T dequeue() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         T returnElement = front.getData();
         front = front.getNext();
@@ -56,7 +57,7 @@ public class LinkedQueue<T> implements Queue<T> {
     @Override
     public T first() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         return front.getData();
     }

--- a/src/main/java/LinkedStack.java
+++ b/src/main/java/LinkedStack.java
@@ -1,3 +1,4 @@
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
@@ -31,7 +32,7 @@ public class LinkedStack<T> implements Stack<T> {
     @Override
     public T pop() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         T returnElement = top.getData();
         top = top.getNext();
@@ -42,7 +43,7 @@ public class LinkedStack<T> implements Stack<T> {
     @Override
     public T peek() {
         if (isEmpty()) {
-            throw new EmptyCollectionException();
+            throw new NoSuchElementException();
         }
         return top.getData();
     }

--- a/src/main/java/LinkedStack.java
+++ b/src/main/java/LinkedStack.java
@@ -32,7 +32,7 @@ public class LinkedStack<T> implements Stack<T> {
     @Override
     public T pop() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty stack");
         }
         T returnElement = top.getData();
         top = top.getNext();
@@ -43,7 +43,7 @@ public class LinkedStack<T> implements Stack<T> {
     @Override
     public T peek() {
         if (isEmpty()) {
-            throw new NoSuchElementException();
+            throw new NoSuchElementException("Empty stack");
         }
         return top.getData();
     }

--- a/src/main/java/PlayingArrayStack.java
+++ b/src/main/java/PlayingArrayStack.java
@@ -1,3 +1,5 @@
+import java.util.NoSuchElementException;
+
 public class PlayingArrayStack {
     public static void main(String[] args) {
         // Create an ArrayStack
@@ -52,12 +54,12 @@ public class PlayingArrayStack {
         // Test peek and pop throwing exception
         try {
             myStack.peek();
-        } catch (EmptyCollectionException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }
         try {
             myStack.pop();
-        } catch (EmptyCollectionException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/PlayingLinkedStack.java
+++ b/src/main/java/PlayingLinkedStack.java
@@ -1,3 +1,5 @@
+import java.util.NoSuchElementException;
+
 public class PlayingLinkedStack {
     public static void main(String[] args) {
         // Create a LinkedStack
@@ -54,12 +56,12 @@ public class PlayingLinkedStack {
         // Test peek and pop throwing exception
         try {
             myStack.peek();
-        } catch (EmptyCollectionException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }
         try {
             myStack.pop();
-        } catch (EmptyCollectionException e) {
+        } catch (NoSuchElementException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/Queue.java
+++ b/src/main/java/Queue.java
@@ -1,3 +1,5 @@
+import java.util.NoSuchElementException;
+
 /**
  * A queue is a linear data structure that has all additions (enqueues) happen at one end (back/tail), and all removals
  * (dequeues) happen at the other end (front/head). Adding and removing from anywhere else but is disallowed. This data
@@ -25,7 +27,7 @@ public interface Queue<T> {
      * If no subsequent element exists, the front will be null and the queue will be empty.
      *
      * @return The element at the front of the queue.
-     * @throws EmptyCollectionException If removing from an empty queue.
+     * @throws NoSuchElementException If removing from an empty queue.
      */
     T dequeue();
 
@@ -34,7 +36,7 @@ public interface Queue<T> {
      * leaves the queue unchanged.
      *
      * @return The element at the front of the queue.
-     * @throws EmptyCollectionException If calling first on an empty queue.
+     * @throws NoSuchElementException If calling first on an empty queue.
      */
     T first();
 

--- a/src/main/java/Stack.java
+++ b/src/main/java/Stack.java
@@ -1,3 +1,5 @@
+import java.util.NoSuchElementException;
+
 /**
  * A stack is a linear data structure that has all the action happen from one end referred to as the top; all additions
  * (pushes) and removals (pops) happen from the same end, the top. Adding and removing from anywhere else in the stack
@@ -23,7 +25,7 @@ public interface Stack<T> {
      * subsequent element exists, the top will be null and the stack will be empty.
      *
      * @return The element at the top of the stack.
-     * @throws EmptyCollectionException If removing from an empty stack.
+     * @throws NoSuchElementException If removing from an empty stack.
      */
     T pop();
 
@@ -32,7 +34,7 @@ public interface Stack<T> {
      * the stack unchanged.
      *
      * @return The element at the top of the stack.
-     * @throws EmptyCollectionException If calling peek on an empty stack.
+     * @throws NoSuchElementException If calling peek on an empty stack.
      */
     T peek();
 

--- a/src/site/topics/stacks/array-stack.rst
+++ b/src/site/topics/stacks/array-stack.rst
@@ -111,8 +111,8 @@ Implementation
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 10
-    :lines: 10-14
+    :lineno-start: 11
+    :lines: 11-15
     :emphasize-lines: 1
 
 
@@ -143,8 +143,8 @@ Constructors
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 16
-    :lines: 16-34
+    :lineno-start: 17
+    :lines: 17-35
     :emphasize-lines: 5, 18
 
 
@@ -181,8 +181,8 @@ Constructors
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 36
-    :lines: 36-56
+    :lineno-start: 37
+    :lines: 37-57
     :emphasize-lines: 1, 3, 4, 5, 15
 
 
@@ -210,8 +210,8 @@ Constructors
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 58
-    :lines: 58-75
+    :lineno-start: 59
+    :lines: 59-76
     :emphasize-lines: 3, 4, 5, 14, 15, 16
 
 
@@ -253,8 +253,8 @@ Exceptional Situations
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 77
-    :lines: 77-85
+    :lineno-start: 78
+    :lines: 78-86
     :emphasize-lines: 3
 
 
@@ -270,8 +270,8 @@ Exceptional Situations
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 87
-    :lines: 87-95
+    :lineno-start: 88
+    :lines: 88-96
     :emphasize-lines: 6
 
 
@@ -286,8 +286,8 @@ Exceptional Situations
 .. literalinclude:: /../main/java/ArrayStack.java
     :language: java
     :linenos:
-    :lineno-start: 97
-    :lines: 97-116
+    :lineno-start: 98
+    :lines: 98-117
     :emphasize-lines: 10
 
 

--- a/src/site/topics/stacks/linked-stack.rst
+++ b/src/site/topics/stacks/linked-stack.rst
@@ -70,8 +70,8 @@ Implementation
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 1
-    :lines: 1-20
+    :lineno-start: 10
+    :lines: 10-21
 
 
 * Like the ``ArrayStack``, the ``LinkedStack`` will implement the ``Stack`` interface
@@ -84,8 +84,8 @@ Implementation
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 22
-    :lines: 22-29
+    :lineno-start: 23
+    :lines: 23-30
 
 
 * In ``push``, notice how this is just *adding to the front of a linked structure*
@@ -98,8 +98,8 @@ Implementation
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 31
-    :lines: 31-48
+    :lineno-start: 32
+    :lines: 32-49
 
 
 * Like the ``ArrayStack``, popping or peeking from an empty stack throws an exception
@@ -112,8 +112,8 @@ Implementation
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 50
-    :lines: 50-58
+    :lineno-start: 51
+    :lines: 51-59
 
 
 * The ``LinkedStack`` is empty if its ``size() == 0``
@@ -127,8 +127,8 @@ Implementation
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 60
-    :lines: 60-70
+    :lineno-start: 61
+    :lines: 61-71
 
 
 * This is matching the output format that the ``ArrayStack``\'s ``toString`` had
@@ -140,8 +140,8 @@ Implementation
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 72
-    :lines: 72-105
+    :lineno-start: 73
+    :lines: 73-106
 
 
 Nested Node Class
@@ -200,8 +200,8 @@ Nesting in LinkedStack
 .. literalinclude:: /../main/java/LinkedStack.java
     :language: java
     :linenos:
-    :lineno-start: 107
-    :lines: 107-142
+    :lineno-start: 108
+    :lines: 108-143
 
 
 
@@ -229,4 +229,4 @@ Playing Code
 .. literalinclude:: /../main/java/PlayingLinkedStack.java
     :language: java
     :linenos:
-    :emphasize-lines: 4
+    :emphasize-lines: 6

--- a/src/test/java/ArrayQueueTest.java
+++ b/src/test/java/ArrayQueueTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ArrayQueueTest {
@@ -31,13 +33,13 @@ public class ArrayQueueTest {
         }
 
         @Test
-        void dequeue_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.dequeue());
+        void dequeue_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.dequeue());
         }
 
         @Test
-        void first_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.first());
+        void first_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.first());
         }
 
         @Test

--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ArrayStackTest {
@@ -31,13 +33,13 @@ class ArrayStackTest {
         }
 
         @Test
-        void pop_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.pop());
+        void pop_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.pop());
         }
 
         @Test
-        void peek_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.peek());
+        void peek_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.peek());
         }
 
         @Test

--- a/src/test/java/LinkedQueueTest.java
+++ b/src/test/java/LinkedQueueTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class LinkedQueueTest {
@@ -31,13 +33,13 @@ class LinkedQueueTest {
         }
 
         @Test
-        void dequeue_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.dequeue());
+        void dequeue_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.dequeue());
         }
 
         @Test
-        void first_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.first());
+        void first_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.first());
         }
 
         @Test

--- a/src/test/java/LinkedStackTest.java
+++ b/src/test/java/LinkedStackTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class LinkedStackTest {
@@ -32,13 +34,13 @@ class LinkedStackTest {
         }
 
         @Test
-        void pop_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.pop());
+        void pop_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.pop());
         }
 
         @Test
-        void peek_empty_throwsEmptyCollectionException() {
-            assertThrows(EmptyCollectionException.class, () -> classUnderTest.peek());
+        void peek_empty_throwsNoSuchElementException() {
+            assertThrows(NoSuchElementException.class, () -> classUnderTest.peek());
         }
 
         @Test


### PR DESCRIPTION
### Related Issues or PRs
#685 

### What
Stop using the `EmptyCollectionException` 

### Why
It's not a standard exception. I figure it's better to go with something that Java already gives you. 

### Where
1. Stack stuff (interface, implementations, tests, playing code)
2. Stack topic (needed to update the line numbers in the literal includes
3. Queue stuff (interface, implementations, tests)

### How
Switched out to a `NoSuchElementException` with a message `Empty stack`/`Empty queue`. I looked for a relevant exception that was just in Java lang, but for better or worse, `NoSuchElementException` seemed to make the most sense. Annoyingly, this meant I needed an import, which threw off the line numbers in the topic code. 

### Testing
:+1:
- Built local, looks good
- Ran unit tests, looks good. 
- Ran playing code, looks good. 

### Additional Notes
There is still reference to an `EmptyCollectionException` and it is used in the topics for queues forward. This will be addressed when these topics actually get cleaned. ~As of _now_. it is used in #683, but this will be changed in that PR.~