### PR TITLE
:bug: :mortar_board: Bag Implementation Topic --- Fix `compareTo` ordering details :microscope: 

### DIFF
--- a/src/site/topics/bags/bag-implementations.rst
+++ b/src/site/topics/bags/bag-implementations.rst
@@ -327,9 +327,9 @@ ArraySortedBag
     * The method ``compareTo`` is implemented for the type
 
 * If we call ``x.compareTo(y)``
-    * Return a negative integer if ``y < x``
-    * Return zero if ``y == x``
-    * Return a positive integer if ``y > x``
+    * Return a negative integer if ``x < y``
+    * Return zero if ``x == y``
+    * Return a positive integer if ``x > y``
 
 * When we have something that is extending ``Comparable<T>``, that means we can compare ``this`` to some type ``T``
     * ``this`` can be compared to things of type ``T``, but not the other way around


### PR DESCRIPTION
### What
Fix the ordering of the elements in the `compareTo` explanation. 

### Why
It was backwards. :grimacing: 

### Testing
Yes, to be sure I wasn't crazy:

```java
        Integer x = Integer.valueOf(1);
        Integer y = Integer.valueOf(2);
        System.out.println(x.compareTo(y));
```
resulted in `-1`


### Additional Notes
This is not part of the cleanup. I just happened to notice so I figured I would fix this ASAP. 
