### PR TITLE
:bug: typo fix for pretend code

### DIFF
--- a/src/site/topics/java-vs-python/java-vs-python.rst
+++ b/src/site/topics/java-vs-python/java-vs-python.rst
@@ -557,7 +557,7 @@ Instance Methods
                 :linenos:
 
                 public void someMethod(int addMe) {
-                    someInstanceVariable += add_me;
+                    someInstanceVariable += addMe;
                 }
 
 


### PR DESCRIPTION
changed the convention for the java code on line 560 from snakecase to camelcase.


