### PR TITLE
:bomb: :technologist: `ArrayStackTest` --- Remove useless tests

### DIFF
--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -27,12 +27,6 @@ class ArrayStackTest {
         }
 
         @Test
-        void push_empty_newTop() {
-            classUnderTest.push(11);
-            assertEquals(11, classUnderTest.peek());
-        }
-
-        @Test
         void pop_empty_throwsNoSuchElementException() {
             assertThrows(NoSuchElementException.class, () -> classUnderTest.pop());
         }
@@ -69,12 +63,6 @@ class ArrayStackTest {
             @Test
             void push_successfullyAdds_returnsTrue() {
                 assertTrue(classUnderTest.push(11));
-            }
-
-            @Test
-            void push_singleton_newTop() {
-                classUnderTest.push(11);
-                assertEquals(11, classUnderTest.peek());
             }
 
             @Test
@@ -131,12 +119,6 @@ class ArrayStackTest {
                 @Test
                 void push_successfullyAdds_returnsTrue() {
                     assertTrue(classUnderTest.push(11));
-                }
-
-                @Test
-                void push_many_newTop() {
-                    classUnderTest.push(11);
-                    assertEquals(11, classUnderTest.peek());
                 }
 
                 @Test


### PR DESCRIPTION
### What
Remove the tests for push resulting in a new top

### Why
They're useless 

### Testing
:+1:

### Additional Notes
I'm not sure why they were there to begin with. I looked at #653 to see if there was an explanation, but there was not. Either way, _if_ the intention was that they were there to point at to explain that they are unnecessary/redundant, this is being explicitly hit in the relevant course topic now. 
