### PR TITLE
:bomb: :technologist: `ArrayQueueTests` --- Remove useless tests

### DIFF
--- a/src/test/java/ArrayQueueTest.java
+++ b/src/test/java/ArrayQueueTest.java
@@ -27,12 +27,6 @@ public class ArrayQueueTest {
         }
 
         @Test
-        void enqueue_empty_newTop() {
-            classUnderTest.enqueue(11);
-            assertEquals(11, classUnderTest.first());
-        }
-
-        @Test
         void dequeue_empty_throwsNoSuchElementException() {
             assertThrows(NoSuchElementException.class, () -> classUnderTest.dequeue());
         }
@@ -70,12 +64,6 @@ public class ArrayQueueTest {
             @Test
             void enqueue_successfullyAdds_returnsTrue() {
                 assertTrue(classUnderTest.enqueue(11));
-            }
-
-            @Test
-            void enqueue_singleton_unchangedFirst() {
-                classUnderTest.enqueue(11);
-                assertEquals(10, classUnderTest.first());
             }
 
             @Test
@@ -133,12 +121,6 @@ public class ArrayQueueTest {
                 @Test
                 void enqueue_successfullyAdds_returnsTrue() {
                     assertTrue(classUnderTest.enqueue(11));
-                }
-
-                @Test
-                void enqueue_many_unchangedFirst() {
-                    classUnderTest.enqueue(11);
-                    assertEquals(10, classUnderTest.first());
                 }
 
                 @Test


### PR DESCRIPTION
### Related Issues or PRs
Similar to #720 

### What
Remove the tests on enqueue resulting in a new or unchanged first

### Why
They're uselesss as this gets tested indirectly 
- push empty new top (which is a typo anyways since it should be `first`, not `top`) is tested with the singleton test on peek
- push singleton unchanged is tested with the many test on peek 

### Testing
:+1: