### PR TITLE
:bug: :lipstick: :technologist:  `ArrayStackTest` --- Change test names

### DIFF
--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -22,7 +22,7 @@ class ArrayStackTest {
     class WhenNewEmpty {
 
         @Test
-        void push_many_returnsTrue() {
+        void push_empty_returnsTrue() {
             assertTrue(classUnderTest.push(11));
         }
 
@@ -61,7 +61,7 @@ class ArrayStackTest {
             }
 
             @Test
-            void push_many_returnsTrue() {
+            void push_singleton_returnsTrue() {
                 assertTrue(classUnderTest.push(11));
             }
 

--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -22,7 +22,7 @@ class ArrayStackTest {
     class WhenNewEmpty {
 
         @Test
-        void push_successfulAdd_returnsTrue() {
+        void push_many_returnsTrue() {
             assertTrue(classUnderTest.push(11));
         }
 
@@ -61,7 +61,7 @@ class ArrayStackTest {
             }
 
             @Test
-            void push_successfullyAdds_returnsTrue() {
+            void push_many_returnsTrue() {
                 assertTrue(classUnderTest.push(11));
             }
 
@@ -117,7 +117,7 @@ class ArrayStackTest {
                 }
 
                 @Test
-                void push_successfullyAdds_returnsTrue() {
+                void push_many_returnsTrue() {
                     assertTrue(classUnderTest.push(11));
                 }
 

--- a/src/test/java/ArrayStackTest.java
+++ b/src/test/java/ArrayStackTest.java
@@ -154,7 +154,7 @@ class ArrayStackTest {
                 }
 
                 @Test
-                void toString_singleton_returnsCorrectString() {
+                void toString_many_returnsCorrectString() {
                     assertEquals("40, 30, 20, 10, ", classUnderTest.toString());
                 }
             }


### PR DESCRIPTION
### Related Issues or PRs
Brought up in #722 

### What
1. Change `toString_singleton_returnsCorrectString` -> `toString_many_returnsCorrectString`
2. Change `push_successfullyAdds_returnsTrue` -> `push_X_returnsTrue` where `X` is the empty, singleton, or many

### Why
1. It was a many test with a bad name
2. Although the nested classes will make it clear if the test is for an empty, singleton, etc. type test, this is a little clearer. And, really, "successfullyAdds" is not really helpful since, based on the way the actual methods are done, there really isn't a way to not successfully add anyways, so something like "successfullyAdds" is meh. Finally, this will make the code consistent with how the tests were presented in the relevant topic. Since the tests started without nested classes, something like "empty" in the test name was more helpful. It only became _less_ helpful when it was added to the nested class. The naming with empty/singleton/many was used throughout the topic for consistency with the nested test classes, thus, this creates inconsistency with the topic and the actual code. 

### Testing
:+1: