### PR TITLE
:lipstick: :bug: :technologist: Other Stack, Queues, and Bags --- Change test names

### DIFF
--- a/src/test/java/ArrayIndexedBagTest.java
+++ b/src/test/java/ArrayIndexedBagTest.java
@@ -441,7 +441,7 @@ public class ArrayIndexedBagTest {
                 }
 
                 @Test
-                void iterator_singleton_returnsElementsInCorrectOrder() {
+                void iterator_many_returnsElementsInCorrectOrder() {
                     List<Integer> list = new ArrayList<>();
                     classUnderTest.iterator().forEachRemaining(list::add);
                     assertEquals(List.of(10, 20, 30, 40, 50), list);

--- a/src/test/java/ArrayIndexedBagTest.java
+++ b/src/test/java/ArrayIndexedBagTest.java
@@ -448,7 +448,7 @@ public class ArrayIndexedBagTest {
                 }
 
                 @Test
-                void toString_singleton_returnsCorrectString() {
+                void toString_many_returnsCorrectString() {
                     assertEquals("10, 20, 30, 40, 50, ", classUnderTest.toString());
                 }
             }

--- a/src/test/java/ArrayQueueTest.java
+++ b/src/test/java/ArrayQueueTest.java
@@ -22,7 +22,7 @@ public class ArrayQueueTest {
     class WhenNewEmpty {
 
         @Test
-        void enqueue_successfullyAdds_returnsTrue() {
+        void enqueue_empty_returnsTrue() {
             assertTrue(classUnderTest.enqueue(11));
         }
 
@@ -62,7 +62,7 @@ public class ArrayQueueTest {
             }
 
             @Test
-            void enqueue_successfullyAdds_returnsTrue() {
+            void enqueue_singleton_returnsTrue() {
                 assertTrue(classUnderTest.enqueue(11));
             }
 
@@ -119,7 +119,7 @@ public class ArrayQueueTest {
 
 
                 @Test
-                void enqueue_successfullyAdds_returnsTrue() {
+                void enqueue_many_returnsTrue() {
                     assertTrue(classUnderTest.enqueue(11));
                 }
 
@@ -156,7 +156,7 @@ public class ArrayQueueTest {
                 }
 
                 @Test
-                void toString_singleton_returnsCorrectString() {
+                void toString_many_returnsCorrectString() {
                     assertEquals("10, 20, 30, 40, ", classUnderTest.toString());
                 }
             }

--- a/src/test/java/ArraySortedBagTest.java
+++ b/src/test/java/ArraySortedBagTest.java
@@ -26,7 +26,7 @@ public class ArraySortedBagTest {
     class WhenNewEmpty {
 
         @Test
-        void add_successfulAdd_returnsTrue() {
+        void add_empty_returnsTrue() {
             assertTrue(classUnderTest.add(0));
         }
 
@@ -105,7 +105,7 @@ public class ArraySortedBagTest {
             }
 
             @Test
-            void add_successfulAdd_returnsTrue() {
+            void add_singleton_returnsTrue() {
                 assertTrue(classUnderTest.add(0));
             }
 
@@ -230,7 +230,7 @@ public class ArraySortedBagTest {
                 }
 
                 @Test
-                void add_successfulAdd_returnsTrue() {
+                void add_many_returnsTrue() {
                     assertTrue(classUnderTest.add(0));
                 }
 
@@ -328,14 +328,14 @@ public class ArraySortedBagTest {
                 }
 
                 @Test
-                void iterator_singleton_returnsElementsInCorrectOrder() {
+                void iterator_many_returnsElementsInCorrectOrder() {
                     List<Integer> list = new ArrayList<>();
                     classUnderTest.iterator().forEachRemaining(list::add);
                     assertEquals(List.of(10, 20, 30, 40, 50), list);
                 }
 
                 @Test
-                void toString_singleton_returnsCorrectString() {
+                void toString_many_returnsCorrectString() {
                     assertEquals("10, 20, 30, 40, 50, ", classUnderTest.toString());
                 }
             }

--- a/src/test/java/LinkedQueueTest.java
+++ b/src/test/java/LinkedQueueTest.java
@@ -22,7 +22,7 @@ class LinkedQueueTest {
     class WhenNewEmpty {
 
         @Test
-        void enqueue_successfullyAdds_returnsTrue() {
+        void enqueue_empty_returnsTrue() {
             assertTrue(classUnderTest.enqueue(11));
         }
 
@@ -68,7 +68,7 @@ class LinkedQueueTest {
             }
 
             @Test
-            void enqueue_successfullyAdds_returnsTrue() {
+            void enqueue_singleton_returnsTrue() {
                 assertTrue(classUnderTest.enqueue(11));
             }
 
@@ -131,7 +131,7 @@ class LinkedQueueTest {
 
 
                 @Test
-                void enqueue_successfullyAdds_returnsTrue() {
+                void enqueue_many_returnsTrue() {
                     assertTrue(classUnderTest.enqueue(11));
                 }
 
@@ -174,7 +174,7 @@ class LinkedQueueTest {
                 }
 
                 @Test
-                void toString_singleton_returnsCorrectString() {
+                void toString_many_returnsCorrectString() {
                     assertEquals("10, 20, 30, 40, ", classUnderTest.toString());
                 }
             }

--- a/src/test/java/LinkedStackTest.java
+++ b/src/test/java/LinkedStackTest.java
@@ -23,7 +23,7 @@ class LinkedStackTest {
     class WhenNewEmpty {
 
         @Test
-        void push_successfulAdd_returnsTrue() {
+        void push_empty_returnsTrue() {
             assertTrue(classUnderTest.push(11));
         }
 
@@ -68,7 +68,7 @@ class LinkedStackTest {
             }
 
             @Test
-            void push_successfullyAdds_returnsTrue() {
+            void push_singleton_returnsTrue() {
                 assertTrue(classUnderTest.push(11));
             }
 
@@ -130,7 +130,7 @@ class LinkedStackTest {
                 }
 
                 @Test
-                void push_successfullyAdds_returnsTrue() {
+                void push_many_returnsTrue() {
                     assertTrue(classUnderTest.push(11));
                 }
 
@@ -173,7 +173,7 @@ class LinkedStackTest {
                 }
 
                 @Test
-                void toString_singleton_returnsCorrectString() {
+                void toString_many_returnsCorrectString() {
                     assertEquals("40, 30, 20, 10, ", classUnderTest.toString());
                 }
             }


### PR DESCRIPTION
### Related Issues or PRs
Same as #723 but for the remaining tests. 

### What
1. Change `toString_singleton_returnsCorrectString` -> `toString_many_returnsCorrectString`
2. The bags had iterator tests with the same issue as 1
3. Change `Y_successfullyAdds_returnsTrue` -> `Y_X_returnsTrue` where `X` is the empty, singleton, or many and `Y` is the way to add (not relevant for indexed bag)

### Why
1 & 2. They were many test with bad names
3 Although the nested classes will make it clear if the test is for an empty, singleton, etc. type test, this is a little clearer. And, really, "successfullyAdds" is not really helpful since, based on the way the actual methods are done, there really isn't a way to not successfully add anyways, so something like "successfullyAdds" is meh. Finally, this will make the code consistent with how the tests were presented in the relevant topic. Since the tests started without nested classes, something like "empty" in the test name was more helpful. It only became _less_ helpful when it was added to the nested class. The naming with empty/singleton/many was used throughout the topic for consistency with the nested test classes, thus, this creates inconsistency with the topic and the actual code. 

### Testing
:+1: 

### Additional Notes
PR was going to only be for the `ArrayQueueTest`, but figured I could get them all here. 
