### PR TITLE
💄🎓  Java vs Python --- Fix typesetting 🔬 

### DIFF
--- a/src/site/topics/java-vs-python/java-vs-python.rst
+++ b/src/site/topics/java-vs-python/java-vs-python.rst
@@ -905,7 +905,8 @@ For Loop
 
 
 * In other words, this loop will run 10 times
-    * ``0 -- 9``
+
+    * ``0`` -- ``9``
 
 
 Comparison of For Loop to While Loop


### PR DESCRIPTION
### What
1. Add a new line between the one point and subpoint
2. Change how the 0 -- 9 is typeset

### Why
1. Without the newline, the _read the docs theme_ makes the parent point boldfaced. I do not like this. 
2. Idk, I just like it slightly better. 

### Testing
:+1: built local, looks good. 