### PR TITLE
:lipstick: :mortar_board: Stack Topic --- Remove space in interface :microscope: 

### DIFF
--- a/src/site/topics/stacks/stack-adt.rst
+++ b/src/site/topics/stacks/stack-adt.rst
@@ -235,7 +235,7 @@ Stack Interface
 .. code-block:: java
     :linenos:
 
-    public interface Stack <T> {
+    public interface Stack<T> {
 
         // Javadoc comments within Stack.java file
         boolean push(T element);


### PR DESCRIPTION
### What
Remove the space between the word `Stack` and `<T>`. 

### Why
Consistency 

### Testing
yolo