### PR TITLE
:lipstick: :technologist: `BinaryNode` --- Update class doc a little more

### DIFF
--- a/src/main/java/BinaryNode.java
+++ b/src/main/java/BinaryNode.java
@@ -1,8 +1,8 @@
 /**
- * A BinaryNode class for a linked binary tree structure. Each BinaryNode contains a nullable reference to data of type
- * T, and a reference to the left and right child BinaryNodes, which may be null references.
+ * A node class for a linked binary tree structure. Each node contains a nullable reference to data of type T, and a
+ * reference to the left and right child nodes, which may be null references.
  *
- * @param <T> Type of the data being stored in the BinaryNode
+ * @param <T> Type of the data being stored in the node.
  */
 public class BinaryNode<T> {
 


### PR DESCRIPTION
### Related Issues or PRs
Small update to #730 

### What
Alter the class doc to not explicitly say "`BinaryNode`". 

### Why
Since this is actually supposed to be an internal class in the `LinkedBinarySearchTree` class called `Node`, it would be lame if the copy/paste from this class to the internal class had to be changed.

### How
Just called it a "binary node" once, and then node everywhere else in the doc. 

### Additional Notes
Obviously there will need to be some change to the class when copy/pasted since it's actual name is changed (`BinaryNode` -> `Node`). But, removing the need for extra changes is nice. 
