### PR TITLE
:new: :mortar_board: Country Catalogue Assignment --- Warn about JUnit 4

### DIFF
--- a/src/site/assignments/country-catalogue/country-catalogue.rst
+++ b/src/site/assignments/country-catalogue/country-catalogue.rst
@@ -119,6 +119,12 @@ instances of the ``Country`` class.
     * It may be necessary to add JUnit to the class path, as described in the :doc:`testing topic </topics/testing/unit-tests>`
 
 
+.. warning::
+
+    Be sure to use JUnit 5. If you use JUnit 4, the tests will not work. Further, if you select JUnit 4 by accident,
+    changing the project to use JUnit 5 can be difficult.
+
+
 
 Part 2 --- Country Catalogue
 ============================

--- a/src/site/assignments/country-catalogue/country-catalogue.rst
+++ b/src/site/assignments/country-catalogue/country-catalogue.rst
@@ -118,11 +118,10 @@ instances of the ``Country`` class.
 
     * It may be necessary to add JUnit to the class path, as described in the :doc:`testing topic </topics/testing/unit-tests>`
 
+    .. warning::
 
-.. warning::
-
-    Be sure to use JUnit 5. If you use JUnit 4, the tests will not work. Further, if you select JUnit 4 by accident,
-    changing the project to use JUnit 5 can be difficult.
+        Be sure to use JUnit 5. If you use JUnit 4, the tests will not work. Further, if you select JUnit 4 by accident,
+        changing the project to use JUnit 5 can be difficult.
 
 
 


### PR DESCRIPTION
### What
Add a warning next to the first mention of running unit tests about using JUnit 5, not JUnit 4. 

### Why
Using JUnit 4 will make the tests, as written, not work. 

### How
Just warn. 

Originally I had details on how to remove the JUnit 4 stuff from the project .iml file, but I figured that's likely to cause more issues. 

### Testing
:+1: built local, looks good. 

The warning, because it is indented under the point, does seem a little smushed next to the previous point, but to me it makes the warning more obvious that it is attached to the specific part of the assignment. 

Indented
![image](https://user-images.githubusercontent.com/1328048/212355507-0441c868-bc68-456a-94f9-60e2ee4d9c2d.png)

Not indented
![image](https://user-images.githubusercontent.com/1328048/212355638-39aaeda8-75a9-456f-8a8b-92451b00eb71.png)

