### PR TITLE
:question: :lipstick: :mortar_board: Objects review topic --- Change literalinclude 

### DIFF
--- a/src/site/topics/objects-review/objects-review.rst
+++ b/src/site/topics/objects-review/objects-review.rst
@@ -345,8 +345,7 @@ Accessors
 
 .. literalinclude:: /../main/java/Friend.java
     :language: java
-    :linenos:
-    :lineno-start: 61
+    :lineno-match:
     :lines: 61-86
 
 
@@ -421,8 +420,7 @@ Accessors
 
 .. literalinclude:: /../main/java/Friend.java
     :language: java
-    :linenos:
-    :lineno-start: 88
+    :lineno-match:
     :lines: 88-91
 
 

--- a/src/site/topics/objects-review/objects-review.rst
+++ b/src/site/topics/objects-review/objects-review.rst
@@ -165,9 +165,9 @@ In Java, the class' declaration of fields, constructor, and assigning values to 
 
 .. literalinclude:: /../main/java/Friend.java
     :language: java
-    :linenos:
-    :lineno-start: 3
-    :lines: 3-26
+    :start-at: /***
+    :end-before: getFirstName
+    :lineno-match:
     :emphasize-lines: 8, 9, 10, 21, 22, 23
 
 
@@ -232,9 +232,9 @@ Accessors
 
 .. literalinclude:: /../main/java/Friend.java
     :language: java
-    :linenos:
-    :lineno-start: 28
-    :lines: 28-38
+    :start-at: getFirstName
+    :end-before: toString
+    :lineno-match:
 
 
 * In Python, accessors were not used as one could simply access the field directly
@@ -290,9 +290,9 @@ Accessors
 
 .. literalinclude:: /../main/java/Friend.java
     :language: java
-    :linenos:
-    :lineno-start: 40
-    :lines: 40-42
+    :start-at: toString
+    :end-at: }
+    :lineno-match:
 
 
 * In the above example, ``String.format`` was used, but string concatenation could have been used


### PR DESCRIPTION
### Related Issues or PRs
#479

### What
Make use of the `:lineno-match:` and `:start-at/after:` & `:end-before/at` directives 

### Why
1. `:lineno-match:` is nice since I do not specify which number to start the line numbers at, so if things in the source change, the argument for `:lineno-start:` doesn't matter. 
2. Helps to protect against changes in the source code screwing up the line numbers in the `literalinclude` 

### Testing
:+1: Built local, looks good. 

### Additional Notes
Using `:lineno-match:` is a winner.

Using `:start-at:` etc. is questionable. It really does not provide enough control to do this right. It requires some not so great starting or ending references that are not immediately obvious and it will only work on the first occurrence of the argument (e.g. `/**` will refer to the first java doc comment). Further, because of the lack of control, some of the `literalinclude`s just can't make use of these directives, which means I am using different ways to get the stuff (some with line numbers, some with these arguments). Despite the arguable improvements in _some_ of the `literalinclude` blocks, the inconsistency annoys me more. 

The more I think about it, I do not like the use of `:start-at:` etc., but I'll leave it in the PR for now to get thoughts. 
