### PR TITLE
:bug: :mortar_board: Objects Review --- Fix note on null safe equals

### DIFF
--- a/src/site/topics/objects-review/objects-review.rst
+++ b/src/site/topics/objects-review/objects-review.rst
@@ -396,8 +396,8 @@ Accessors
 
     The above example makes use of the third option to be safe around ``null``. This is important because, based on the
     way the class is written, it is possible to have the fields reference ``null``. Consider creating a ``Friend``
-    object with the following --- new Friend(null, "Smith", "bsmith@gmail.com"). This would make the field ``firstName``
-    reference ``null``, meaning a call to ``this.firstName.equals(other.firstName)`` would result in a null pointer
+    object with the following --- ``new Friend(null, "Smith", "bsmith@gmail.com")``. This would make the field
+    ``firstName`` reference ``null``, meaning a call to ``this.firstName.equals(other.firstName)`` would result in a null pointer
     exception.
 
 

--- a/src/site/topics/objects-review/objects-review.rst
+++ b/src/site/topics/objects-review/objects-review.rst
@@ -394,9 +394,11 @@ Accessors
     ``null``.
     `Have a look at the relevant javadocs <https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Objects.html#equals(java.lang.Object,java.lang.Object)>`__
 
-    The below example makes use of the third option to be safe around ``null``, but realistically, based on the way the
-    ``Friend`` class is written, it is not possible for an instance of a ``Friend`` object to be created with ``null``
-    fields. In other words, the second option would be fine, but using the third option would still be more defensive.
+    The above example makes use of the third option to be safe around ``null``. This is important because, based on the
+    way the class is written, it is possible to have the fields reference ``null``. Consider creating a ``Friend``
+    object with the following --- new Friend(null, "Smith", "bsmith@gmail.com"). This would make the field ``firstName``
+    reference ``null``, meaning a call to ``this.firstName.equals(other.firstName)`` would result in a null pointer
+    exception.
 
 
 ``hashCode``


### PR DESCRIPTION
### What
1. Say "above" instead of "below"
2. Explain that one can actually screw up with the way the `Friend` class is written

### Why
1. It's above, not below (was below when it was in the aside) 
2. It was wrong

### Testing
:+1: built local, looks good. 