### PR TITLE
:bug: :mortar_board: Stack ADT Topic --- Fix maze dimension :microscope: 

### DIFF
--- a/src/site/topics/stacks/stack-adt.rst
+++ b/src/site/topics/stacks/stack-adt.rst
@@ -123,7 +123,7 @@ Maze Solving
         :width: 250 px
         :align: center
 
-        A 6x6 maze. The green and red cells represent the start and end locations respectively. Black cells represent
+        A 6x7 maze. The green and red cells represent the start and end locations respectively. Black cells represent
         walls and light blue represent open spaces.
 
 


### PR DESCRIPTION
### What
6x6 -> 6x7

### Why
The maze is 6x7 not 6x6

### Testing
:-1: YOLO 

### Additional Notes
Is there a convention? Should it be 6x7 or 7x6? 6x7 _sounds_ better to me, but idk why. 
