### PR TITLE
:bug: :technologist: Unit Tests --- Fix names of create methods :microscope:  

### DIFF
--- a/src/main/java/ArrayIterator.java
+++ b/src/main/java/ArrayIterator.java
@@ -4,18 +4,18 @@ import java.util.NoSuchElementException;
 public class ArrayIterator<T> implements Iterator<T> {
 
     private final int size;
-    private int currentIndex;
-    private final T[] items;
+    private final T[] elements;
+    private int index;
 
-    public ArrayIterator(T[] items, int size) {
-        this.items = items;
+    public ArrayIterator(T[] elements, int size) {
+        this.elements = elements;
         this.size = size;
-        this.currentIndex = 0;
+        this.index = 0;
     }
 
     @Override
     public boolean hasNext() {
-        return currentIndex < size;
+        return index < size;
     }
 
     @Override
@@ -23,8 +23,8 @@ public class ArrayIterator<T> implements Iterator<T> {
         if (!hasNext()) {
             throw new NoSuchElementException();
         }
-        T returnElement = items[currentIndex];
-        currentIndex++;
+        T returnElement = elements[index];
+        index++;
         return returnElement;
     }
 }

--- a/src/test/java/ArrayIndexedBagTest.java
+++ b/src/test/java/ArrayIndexedBagTest.java
@@ -16,7 +16,7 @@ public class ArrayIndexedBagTest {
     private ArrayIndexedBag<Integer> classUnderTest;
 
     @BeforeEach
-    void createStack() {
+    void createIndexedBag() {
         classUnderTest = new ArrayIndexedBag<>();
     }
 

--- a/src/test/java/ArrayIteratorTest.java
+++ b/src/test/java/ArrayIteratorTest.java
@@ -1,4 +1,7 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -7,9 +10,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ArrayIteratorTest {
 
-    // Note:
-    //      Size is the number of "meaningful" elements in the array
-    //      Capacity is the number of available indices in the array
+
+    private ArrayIterator<Integer> classUnderTest;
+    private ArrayIterator<Integer> preState;
+
+    @BeforeEach
+    void createIterator() {
+        classUnderTest = new ArrayIterator<>(new Integer[10], 0);
+        preState = new ArrayIterator<>(new Integer[10], 0);
+    }
 
     @Test
     void hasNext_capacityZeroArray_returnsFalse() {
@@ -17,6 +26,11 @@ public class ArrayIteratorTest {
         Iterator<Integer> it = new ArrayIterator<>(a, 0);
         assertFalse(it.hasNext());
     }
+
+
+    // Note:
+    //      Size is the number of "meaningful" elements in the array
+    //      Capacity is the number of available indices in the array
 
     @Test
     void hasNext_fullCapacityOneArray_returnsTrue() {
@@ -150,5 +164,26 @@ public class ArrayIteratorTest {
             it.next();
         }
         assertThrows(NoSuchElementException.class, () -> it.next());
+    }
+
+    @Nested
+    class WhenNewEmpty {
+
+        @Nested
+        class WhenSingleton {
+
+            @BeforeEach
+            void addSingleton() {
+                @Nested
+                @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+                class WhenMany {
+
+                    @BeforeEach
+                    void addMany() {
+
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/test/java/ArrayQueueTest.java
+++ b/src/test/java/ArrayQueueTest.java
@@ -13,7 +13,7 @@ public class ArrayQueueTest {
     private ArrayQueue<Integer> preState;
 
     @BeforeEach
-    void createStack() {
+    void createQueue() {
         classUnderTest = new ArrayQueue<>();
         preState = new ArrayQueue<>();
     }

--- a/src/test/java/ArraySortedBagTest.java
+++ b/src/test/java/ArraySortedBagTest.java
@@ -18,7 +18,7 @@ public class ArraySortedBagTest {
     private ArraySortedBag<Integer> classUnderTest;
 
     @BeforeEach
-    void createStack() {
+    void createSortedBag() {
         classUnderTest = new ArraySortedBag<>();
     }
 

--- a/src/test/java/LinkedQueueTest.java
+++ b/src/test/java/LinkedQueueTest.java
@@ -13,7 +13,7 @@ class LinkedQueueTest {
     private LinkedQueue<Integer> preState;
 
     @BeforeEach
-    void createStack() {
+    void createQueue() {
         classUnderTest = new LinkedQueue<>();
         preState = new LinkedQueue<>();
     }


### PR DESCRIPTION
### What
Change the various `@BeforeEach` method names.

### Why
Several said "stack" when they had nothing to do with stack. 

### Testing
:+1:

### Additional Notes
Caused by lazy copy/pastes I guess. 

