### PR TITLE
:bug: :technologist: Unit Tests --- Rename setup tests :microscope: 

### DIFF
--- a/src/test/java/ArrayIndexedBagTest.java
+++ b/src/test/java/ArrayIndexedBagTest.java
@@ -16,7 +16,7 @@ public class ArrayIndexedBagTest {
     private ArrayIndexedBag<Integer> classUnderTest;
 
     @BeforeEach
-    void createStack() {
+    void createIndexedBag() {
         classUnderTest = new ArrayIndexedBag<>();
     }
 

--- a/src/test/java/ArrayQueueTest.java
+++ b/src/test/java/ArrayQueueTest.java
@@ -13,7 +13,7 @@ public class ArrayQueueTest {
     private ArrayQueue<Integer> preState;
 
     @BeforeEach
-    void createStack() {
+    void createQueue() {
         classUnderTest = new ArrayQueue<>();
         preState = new ArrayQueue<>();
     }

--- a/src/test/java/ArraySortedBagTest.java
+++ b/src/test/java/ArraySortedBagTest.java
@@ -18,7 +18,7 @@ public class ArraySortedBagTest {
     private ArraySortedBag<Integer> classUnderTest;
 
     @BeforeEach
-    void createStack() {
+    void createSortedBag() {
         classUnderTest = new ArraySortedBag<>();
     }
 

--- a/src/test/java/LinkedQueueTest.java
+++ b/src/test/java/LinkedQueueTest.java
@@ -13,7 +13,7 @@ class LinkedQueueTest {
     private LinkedQueue<Integer> preState;
 
     @BeforeEach
-    void createStack() {
+    void createQueue() {
         classUnderTest = new LinkedQueue<>();
         preState = new LinkedQueue<>();
     }


### PR DESCRIPTION
### Related Issues or PRs
Redo of #766 

### What
Rename `@BeforeEach` tests for queue and bag tests 

### Why
They included "stack" when they had nothing to do with stacks. 

### Testing
:+1:

### Additional Notes
Caused by lazy copy/paste I assume
