### PR TITLE
:bomb: :mortar_board: Array Queue Topic --- Remove expand capacity warning

### DIFF
--- a/src/site/topics/queues/array-queue.rst
+++ b/src/site/topics/queues/array-queue.rst
@@ -424,11 +424,6 @@ Implementing a Queue --- Array Container
     * When ``front`` is ``0``, ``rear`` must be equal to ``size``
 
 
-.. warning::
-
-    Take time to understand this one as there is some nuance here.
-
-
 
 ``dequeue``
 -----------


### PR DESCRIPTION
### What
Remove the warning about understanding expand capacity

### Why
Feels silly to warn about learning something I told them to learn. Also, there is an aside that goes into more detail. 