### PR TITLE
:lipstick: :woman_technologist: Use `size()` where it makes sense

### DIFF
--- a/src/main/java/ArrayQueue.java
+++ b/src/main/java/ArrayQueue.java
@@ -59,7 +59,7 @@ public class ArrayQueue<T> implements Queue<T> {
             front = nextIndex(front);
         }
         front = 0;
-        rear = size;
+        rear = size();
         queue = newQueue;
     }
 
@@ -107,7 +107,7 @@ public class ArrayQueue<T> implements Queue<T> {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         int currentIndex = front;
-        for (int i = 0; i < size; ++i) {
+        for (int i = 0; i < size(); ++i) {
             builder.append(queue[currentIndex]);
             builder.append(", ");
             currentIndex = nextIndex(currentIndex);
@@ -124,13 +124,13 @@ public class ArrayQueue<T> implements Queue<T> {
             return false;
         }
         ArrayQueue<?> that = (ArrayQueue<?>) o;
-        if (this.size != that.size) {
+        if (this.size() != that.size()) {
             return false;
         }
         int thisCurrentIndex = this.front;
         int thatCurrentIndex = that.front;
-        // Since this and that are the same size, this.size can be used safely in the for loop
-        for (int i = 0; i < this.size; i++) {
+        // Since this and that are the same size, this.size() can be used safely in the for loop
+        for (int i = 0; i < this.size(); i++) {
             if (!Objects.equals(this.queue[thisCurrentIndex], that.queue[thatCurrentIndex])) {
                 return false;
             }
@@ -144,7 +144,7 @@ public class ArrayQueue<T> implements Queue<T> {
     public int hashCode() {
         int result = Objects.hashCode(size);
         int currentIndex = front;
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < size(); i++) {
             result = result * 97 + Objects.hashCode(queue[currentIndex]);
             currentIndex = nextIndex(currentIndex);
         }

--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -104,7 +104,7 @@ public class ArrayStack<T> implements Stack<T> {
             return false;
         }
         ArrayStack<?> that = (ArrayStack<?>) o;
-        return Arrays.equals(this.stack, 0, this.top, that.stack, 0, that.top);
+        return Arrays.equals(this.stack, 0, this.size(), that.stack, 0, that.size());
     }
 
     @Override

--- a/src/main/java/ContactList.java
+++ b/src/main/java/ContactList.java
@@ -203,7 +203,7 @@ public class ContactList {
 
     @Override
     public final int hashCode() {
-        int result = Objects.hash(this.size());
+        int result = Objects.hash(this.size);
         for (int i = 0; i < this.size(); i++) {
             result = result * 97 + Objects.hashCode(this.friends[i]);
         }

--- a/src/main/java/LinkedQueue.java
+++ b/src/main/java/LinkedQueue.java
@@ -93,7 +93,7 @@ public class LinkedQueue<T> implements Queue<T> {
             return false;
         }
         LinkedQueue<?> that = (LinkedQueue<?>) o;
-        if (this.size != that.size) {
+        if (this.size() != that.size()) {
             return false;
         }
         Node<?> thisCurrent = this.front;


### PR DESCRIPTION
### Related Issues or PRs
#169

### What
Change `top`/`rear`/`size` to the method call `size()` where it makes _sense_. 

### Why
1. Consistency
2. Improve quality of code --- do we care about `size()` here or the arbitrary field?

### How
I tried to make use of `size()` where it makes sense. For example, are we looping to `rear` or `size()`? Both are correct, but `size()` is clearer in the context. For another example, are we hashing the value of `size()` or the value of the field that happens to represent the size? Again, both are correct, but it's not _size_ that matters, but the value of the field that's hashed. 

This does get weird though, because, 

```java
    private void shiftLeft(int start) {
        for (int i = start; i < rear - 1; i++) {
            bag[i] = bag[i + 1];
        }
        bag[rear - 1] = null;
    }
```
why not change `rear` to `size()`? That would be valid, but idk, feels like it's clearer left as `rear` here since it's the meaning of rear that is more important than size in this context. End of the day though, it could go both ways. 

A lot of this seems like _eye of the beholder_ stuff, but I think the changes at least make an improvement. Not saying the respective code is necessarily in their best possible state though. 

### Testing
:+1:
