### PR TITLE
:telescope: :mortar_board: Stack ADT Topic --- Remove ".java" from download link

### DIFF
--- a/src/site/topics/stacks/stack-adt.rst
+++ b/src/site/topics/stacks/stack-adt.rst
@@ -346,4 +346,4 @@ For Next Time
 Playing Code
 ------------
 
-* Download and play with the :download:`Stack.java</../main/java/Stack.java>` interface
+* Download and play with the :download:`Stack</../main/java/Stack.java>` interface


### PR DESCRIPTION
### What
Remove the :.java" from the download link

### Why
1. I don't like it
2. It is not typically used throughout the course
