### PR TITLE
:bug: :mortar_board: Unit testing collections topic --- Add missing call and fix typos 

### DIFF
--- a/src/site/topics/testing/unit-test-collections.rst
+++ b/src/site/topics/testing/unit-test-collections.rst
@@ -348,7 +348,7 @@ Nested Test Classes
             }
 
             @Test
-            void push_empty_returnsTrue() {
+            void push_singleton_returnsTrue() {
                 assertTrue(classUnderTest.push(11));
             }
 

--- a/src/site/topics/testing/unit-test-collections.rst
+++ b/src/site/topics/testing/unit-test-collections.rst
@@ -208,6 +208,7 @@ Singleton Case Stack Tests
     @Test
     void pop_singleton_returnsTop() {
         classUnderTest.push(10);
+        preState.push(10);
         assertEquals(10, classUnderTest.pop());
     }
 


### PR DESCRIPTION
### What
1. Add the missing `push` on `preState` in the one test
2. Fix the name of the singleton test to not say "empty"