### PR TITLE
:lipstick: :mortar_board: Linked queue topic --- Queue -> queue :microscope: 

### DIFF
--- a/src/site/topics/queues/linked-queue.rst
+++ b/src/site/topics/queues/linked-queue.rst
@@ -2,7 +2,7 @@
 LinkedQueue
 ***********
 
-* Given the definition of a Queue, how can it be implemented?
+* Given the definition of a queue, how can it be implemented?
 
     * Remember, the *what* and the *how* are separate
 


### PR DESCRIPTION
### What
Change Queue -> queue in the first line in the intro 

### Why
it shouldn't start with an upper case here, unless it was `Queue`, which it _could_ be, but it's really not talking specifically about the interface. 