### PR TITLE
:lipstick: :technologist: `SearchingMethods` --- Clean :broom: 

### DIFF
--- a/src/main/java/SearchingFunctions.java
+++ b/src/main/java/SearchingFunctions.java
@@ -1,6 +1,6 @@
 import java.util.Objects;
 
-public class SearchingMethods {
+public class SearchingFunctions {
 
     private static final int NOT_FOUND = -1;
 

--- a/src/main/java/SearchingMethods.java
+++ b/src/main/java/SearchingMethods.java
@@ -30,7 +30,7 @@ public class SearchingMethods {
         int midpoint = (highIndex - lowIndex) / 2;
 
         while (lowIndex < highIndex) {
-            if (Objects.compare(haystack[midpoint], needle, T::compareTo) == 0) {
+            if (haystack[midpoint].compareTo(needle) == 0) {
                 return midpoint;
             } else if (Objects.compare(haystack[midpoint], needle, T::compareTo) > 0) {
                 highIndex = midpoint - 1;
@@ -48,7 +48,7 @@ public class SearchingMethods {
             return NOT_FOUND;
         }
         int midpoint = lowIndex + (highIndex - lowIndex) / 2;
-        if (Objects.compare(haystack[midpoint], needle, T::compareTo) == 0) {
+        if (haystack[midpoint].compareTo(needle) == 0) {
             return midpoint;
         } else if (Objects.compare(haystack[midpoint], needle, T::compareTo) > 0) {
             return recursiveBinarySearch(needle, haystack, lowIndex, midpoint - 1);

--- a/src/main/java/SearchingMethods.java
+++ b/src/main/java/SearchingMethods.java
@@ -1,8 +1,10 @@
+import java.util.Objects;
+
 public class SearchingMethods {
 
     public static <T> int iterativeLinearSearch(T needle, T[] haystack) {
-        for (int i = 0; i < haystack.length; ++i) {
-            if (haystack[i].equals(needle)) {
+        for (int i = 0; i < haystack.length; i++) {
+            if (Objects.equals(haystack[i], needle)) {
                 return i;
             }
         }

--- a/src/main/java/SearchingMethods.java
+++ b/src/main/java/SearchingMethods.java
@@ -15,7 +15,7 @@ public class SearchingMethods {
         // Not Found
         if (currentIndex == haystack.length) {
             return -1;
-        } else if (haystack[currentIndex].equals(needle)) {
+        } else if (Objects.equals(haystack[currentIndex], needle)) {
             return currentIndex;
         } else {
             return recursiveLinearSearch(needle, haystack, currentIndex + 1);

--- a/src/main/java/SearchingMethods.java
+++ b/src/main/java/SearchingMethods.java
@@ -28,9 +28,9 @@ public class SearchingMethods {
         int midpoint = (highIndex - lowIndex) / 2;
 
         while (lowIndex < highIndex) {
-            if (haystack[midpoint].equals(needle)) {
+            if (Objects.compare(haystack[midpoint], needle, T::compareTo) == 0) {
                 return midpoint;
-            } else if (haystack[midpoint].compareTo(needle) > 0) {
+            } else if (Objects.compare(haystack[midpoint], needle, T::compareTo) > 0) {
                 highIndex = midpoint - 1;
                 midpoint = lowIndex + (highIndex - lowIndex) / 2;
             } else {
@@ -46,9 +46,9 @@ public class SearchingMethods {
             return -1;
         }
         int midpoint = lowIndex + (highIndex - lowIndex) / 2;
-        if (haystack[midpoint].equals(needle)) {
+        if (Objects.compare(haystack[midpoint], needle, T::compareTo) == 0) {
             return midpoint;
-        } else if (haystack[midpoint].compareTo(needle) > 0) {
+        } else if (Objects.compare(haystack[midpoint], needle, T::compareTo) > 0) {
             return recursiveBinarySearch(needle, haystack, lowIndex, midpoint - 1);
         } else {
             return recursiveBinarySearch(needle, haystack, midpoint + 1, highIndex);

--- a/src/main/java/SearchingMethods.java
+++ b/src/main/java/SearchingMethods.java
@@ -2,19 +2,21 @@ import java.util.Objects;
 
 public class SearchingMethods {
 
+    private static final int NOT_FOUND = -1;
+
     public static <T> int iterativeLinearSearch(T needle, T[] haystack) {
         for (int i = 0; i < haystack.length; i++) {
             if (Objects.equals(haystack[i], needle)) {
                 return i;
             }
         }
-        return -1;
+        return NOT_FOUND;
     }
 
     public static <T> int recursiveLinearSearch(T needle, T[] haystack, int currentIndex) {
         // Not Found
         if (currentIndex == haystack.length) {
-            return -1;
+            return NOT_FOUND;
         } else if (Objects.equals(haystack[currentIndex], needle)) {
             return currentIndex;
         } else {
@@ -38,12 +40,12 @@ public class SearchingMethods {
                 midpoint = lowIndex + (highIndex - lowIndex) / 2;
             }
         }
-        return -1;
+        return NOT_FOUND;
     }
 
     public static <T extends Comparable<? super T>> int recursiveBinarySearch(T needle, T[] haystack, int lowIndex, int highIndex) {
         if (lowIndex >= highIndex) {
-            return -1;
+            return NOT_FOUND;
         }
         int midpoint = lowIndex + (highIndex - lowIndex) / 2;
         if (Objects.compare(haystack[midpoint], needle, T::compareTo) == 0) {

--- a/src/site/topics/searching/searching.rst
+++ b/src/site/topics/searching/searching.rst
@@ -236,7 +236,7 @@ Recursive
 For next time
 =============
 
-* Download and play with the :download:`SearchingMethods </../main/java/SearchingMethods.java>` class
-* Download and run the :download:`SearchingMethodsTest </../test/java/SearchingMethodsTest.java>` tests
+* Download and play with the :download:`SearchingFunctions </../main/java/SearchingFunctions.java>` class
+* Download and run the :download:`SearchingFunctionsTest </../test/java/SearchingFunctionsTest.java>` tests
 * Read Chapter 9 Section 1
     * 7 pages

--- a/src/test/java/SearchingFunctionsTest.java
+++ b/src/test/java/SearchingFunctionsTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SearchingMethodsTest {
+public class SearchingFunctionsTest {
 
     private static final Integer[] UNSORTED_ARRAY = {33, 36, 35, 37, 40, 40, 49, 55, 61, 98, 18, 12, 8, 4, 0, 40, 25, 31, 62, 63, 74, 81, 89, 90};
     private static final Integer[] SORTED_ARRAY = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
@@ -16,140 +16,140 @@ public class SearchingMethodsTest {
 
     @Test
     void iterativeLinearSearch_nullHaystack_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeLinearSearch(99, null));
+        assertThrows(NullPointerException.class, () -> SearchingFunctions.iterativeLinearSearch(99, null));
     }
 
     @Test
     void iterativeLinearSearch_nullNeedle_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch(null, UNSORTED_ARRAY));
+        assertEquals(NOT_FOUND, SearchingFunctions.iterativeLinearSearch(null, UNSORTED_ARRAY));
     }
 
     @Test
     void iterativeLinearSearch_mismatchTypes_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch("99", UNSORTED_ARRAY));
+        assertEquals(NOT_FOUND, SearchingFunctions.iterativeLinearSearch("99", UNSORTED_ARRAY));
     }
 
     @Test
     void iterativeLinearSearch_sizeZeroHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch(99, new Integer[0]));
+        assertEquals(NOT_FOUND, SearchingFunctions.iterativeLinearSearch(99, new Integer[0]));
     }
 
     @Test
     void iterativeLinearSearch_needleNotWithinHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch(NOT_WITHIN_HAYSTACK, UNSORTED_ARRAY));
+        assertEquals(NOT_FOUND, SearchingFunctions.iterativeLinearSearch(NOT_WITHIN_HAYSTACK, UNSORTED_ARRAY));
     }
 
     @ParameterizedTest
     @CsvSource({"33,0", "0,14", "90,23"})
     void iterativeLinearSearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
-        assertEquals(index, SearchingMethods.iterativeLinearSearch(needle, UNSORTED_ARRAY));
+        assertEquals(index, SearchingFunctions.iterativeLinearSearch(needle, UNSORTED_ARRAY));
     }
 
     @Test
     void iterativeLinearSearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
-        assertEquals(4, SearchingMethods.iterativeLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY));
+        assertEquals(4, SearchingFunctions.iterativeLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY));
     }
 
     @Test
     void recursiveLinearSearch_nullHaystack_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveLinearSearch(99, null, 0));
+        assertThrows(NullPointerException.class, () -> SearchingFunctions.recursiveLinearSearch(99, null, 0));
     }
 
     @Test
     void recursiveLinearSearch_nullNeedle_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch(null, UNSORTED_ARRAY, 0));
+        assertEquals(NOT_FOUND, SearchingFunctions.recursiveLinearSearch(null, UNSORTED_ARRAY, 0));
     }
 
     @Test
     void recursiveLinearSearch_mismatchTypes_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch("99", UNSORTED_ARRAY, 0));
+        assertEquals(NOT_FOUND, SearchingFunctions.recursiveLinearSearch("99", UNSORTED_ARRAY, 0));
     }
 
     @Test
     void recursiveLinearSearch_sizeZeroHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch(99, new Integer[0], 0));
+        assertEquals(NOT_FOUND, SearchingFunctions.recursiveLinearSearch(99, new Integer[0], 0));
     }
 
     @Test
     void recursiveLinearSearch_needleNotWithinHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch(NOT_WITHIN_HAYSTACK, UNSORTED_ARRAY, 0));
+        assertEquals(NOT_FOUND, SearchingFunctions.recursiveLinearSearch(NOT_WITHIN_HAYSTACK, UNSORTED_ARRAY, 0));
     }
 
     @ParameterizedTest
     @CsvSource({"33,0", "0,14", "90,23"})
     void recursiveLinearSearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
-        assertEquals(index, SearchingMethods.recursiveLinearSearch(needle, UNSORTED_ARRAY, 0));
+        assertEquals(index, SearchingFunctions.recursiveLinearSearch(needle, UNSORTED_ARRAY, 0));
     }
 
     @Test
     void recursiveLinearSearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
-        assertEquals(4, SearchingMethods.recursiveLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY, 0));
+        assertEquals(4, SearchingFunctions.recursiveLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY, 0));
     }
 
     @Test
     void iterativeBinarySearch_nullHaystack_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(99, null));
+        assertThrows(NullPointerException.class, () -> SearchingFunctions.iterativeBinarySearch(99, null));
     }
 
     @Test
     void iterativeBinarySearch_nullNeedle_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(null, SORTED_ARRAY));
+        assertThrows(NullPointerException.class, () -> SearchingFunctions.iterativeBinarySearch(null, SORTED_ARRAY));
     }
 
     @Test
     void iterativeBinarySearch_sizeZeroHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.iterativeBinarySearch(99, new Integer[0]));
+        assertEquals(NOT_FOUND, SearchingFunctions.iterativeBinarySearch(99, new Integer[0]));
     }
 
     @Test
     void iterativeBinarySearch_needleNotWithinHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.iterativeBinarySearch(NOT_WITHIN_HAYSTACK, SORTED_ARRAY));
+        assertEquals(NOT_FOUND, SearchingFunctions.iterativeBinarySearch(NOT_WITHIN_HAYSTACK, SORTED_ARRAY));
     }
 
     @ParameterizedTest
     @CsvSource({"0,0", "37,10", "98,23"})
     void iterativeBinarySearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
-        assertEquals(index, SearchingMethods.iterativeBinarySearch(needle, SORTED_ARRAY));
+        assertEquals(index, SearchingFunctions.iterativeBinarySearch(needle, SORTED_ARRAY));
     }
 
     @Test
     void iterativeBinarySearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
-        assertEquals(12, SearchingMethods.iterativeBinarySearch(DUPLICATE_NEEDLE, SORTED_ARRAY));
+        assertEquals(12, SearchingFunctions.iterativeBinarySearch(DUPLICATE_NEEDLE, SORTED_ARRAY));
     }
 
 
     @Test
     void recursiveBinarySearch_nullHaystack_throwsNullPointerException() {
-        SearchingMethods.recursiveBinarySearch(99, null, 0, 0);
-        assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveBinarySearch(99, null, 0, 1));
+        SearchingFunctions.recursiveBinarySearch(99, null, 0, 0);
+        assertThrows(NullPointerException.class, () -> SearchingFunctions.recursiveBinarySearch(99, null, 0, 1));
     }
 
     @Test
     void recursiveBinarySearch_nullNeedle_throwsNullPointerException() {
         assertThrows(NullPointerException.class,
-                () -> SearchingMethods.recursiveBinarySearch(null, SORTED_ARRAY, 0, 1));
+                () -> SearchingFunctions.recursiveBinarySearch(null, SORTED_ARRAY, 0, 1));
     }
 
     @Test
     void recursiveBinarySearch_sizeZeroHaystack_returnsSentinel() {
-        assertEquals(NOT_FOUND, SearchingMethods.recursiveBinarySearch(99, new Integer[0], 0, 0));
+        assertEquals(NOT_FOUND, SearchingFunctions.recursiveBinarySearch(99, new Integer[0], 0, 0));
     }
 
     @Test
     void recursiveBinarySearch_needleNotWithinHaystack_returnsSentinel() {
         assertEquals(NOT_FOUND,
-                SearchingMethods.recursiveBinarySearch(NOT_WITHIN_HAYSTACK, SORTED_ARRAY, 0, SORTED_ARRAY.length));
+                SearchingFunctions.recursiveBinarySearch(NOT_WITHIN_HAYSTACK, SORTED_ARRAY, 0, SORTED_ARRAY.length));
     }
 
     @ParameterizedTest
     @CsvSource({"0,0", "37,10", "98,23"})
     void recursiveBinarySearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
-        assertEquals(index, SearchingMethods.recursiveBinarySearch(needle, SORTED_ARRAY, 0, SORTED_ARRAY.length));
+        assertEquals(index, SearchingFunctions.recursiveBinarySearch(needle, SORTED_ARRAY, 0, SORTED_ARRAY.length));
     }
 
     @Test
     void recursiveBinarySearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
         assertEquals(12,
-                SearchingMethods.recursiveBinarySearch(DUPLICATE_NEEDLE, SORTED_ARRAY, 0, SORTED_ARRAY.length));
+                SearchingFunctions.recursiveBinarySearch(DUPLICATE_NEEDLE, SORTED_ARRAY, 0, SORTED_ARRAY.length));
     }
 }

--- a/src/test/java/SearchingMethodsTest.java
+++ b/src/test/java/SearchingMethodsTest.java
@@ -1,68 +1,58 @@
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SearchingMethodsTest {
 
+    private static final Integer[] UNSORTED_ARRAY = {33, 36, 35, 37, 40, 40, 49, 55, 61, 98, 18, 12, 8, 4, 0, 40, 25, 31, 62, 63, 74, 81, 89, 90};
+    private static final Integer[] SORTED_ARRAY = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
+
+    private static final Integer NOT_WITHIN_HAYSTACK = 99;
+    private static final Integer DUPLICATE_NEEDLE = 40;
+    private static final int NOT_FOUND = -1;
+
     @Test
-    void iterativeLinearSearch_nullHaystack_throwsException() {
-        Integer[] myHaystack = null;
-        Integer myNeedle = 99;
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
+    void iterativeLinearSearch_nullHaystack_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeLinearSearch(99, null));
+    }
+
+    @Test
+    void iterativeLinearSearch_nullNeedle_returnsSentinel() {
+        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch(null, UNSORTED_ARRAY));
     }
 
     @Test
     void iterativeLinearSearch_mismatchTypes_returnsSentinel() {
-        Integer[] myHaystack = new Integer[0];
-        String myNeedle = "99";
-        assertEquals(-1, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
+        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch("99", UNSORTED_ARRAY));
     }
 
     @Test
     void iterativeLinearSearch_sizeZeroHaystack_returnsSentinel() {
-        Integer[] myHaystack = new Integer[0];
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
+        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch(99, new Integer[0]));
     }
 
     @Test
     void iterativeLinearSearch_needleNotWithinHaystack_returnsSentinel() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
+        assertEquals(NOT_FOUND, SearchingMethods.iterativeLinearSearch(NOT_WITHIN_HAYSTACK, UNSORTED_ARRAY));
     }
 
-    @Test
-    void iterativeLinearSearch_needleAtZeroIndex_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 0;
-        assertEquals(0, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
-    }
-
-    @Test
-    void iterativeLinearSearch_needleAtEndOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 98;
-        assertEquals(23, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
-    }
-
-    @Test
-    void iterativeLinearSearch_needleAtMiddleOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 55;
-        assertEquals(15, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
+    @ParameterizedTest
+    @CsvSource({"33,0", "0,14", "90,23"})
+    void iterativeLinearSearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
+        assertEquals(index, SearchingMethods.iterativeLinearSearch(needle, UNSORTED_ARRAY));
     }
 
     @Test
     void iterativeLinearSearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 40;
-        assertEquals(11, SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
+        assertEquals(4, SearchingMethods.iterativeLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY));
     }
 
+
     @Test
-    void recursiveLinearSearch_nullHaystack_throwsException() {
+    void recursiveLinearSearch_nullHaystack_throwsNullPointerException() {
         Integer[] myHaystack = null;
         Integer myNeedle = 99;
         assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
@@ -70,7 +60,7 @@ public class SearchingMethodsTest {
 
     @Test
     void recursiveLinearSearch_mismatchTypes_returnsSentinel() {
-        Integer[] myHaystack = new Integer[0];
+        Integer[] myHaystack = new Integer[10];
         String myNeedle = "99";
         assertEquals(-1, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
     }
@@ -118,7 +108,7 @@ public class SearchingMethodsTest {
     }
 
     @Test
-    void iterativeBinarySearch_nullHaystack_throwsException() {
+    void iterativeBinarySearch_nullHaystack_throwsNullPointerException() {
         Integer[] myHaystack = null;
         Integer myNeedle = 99;
         assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
@@ -160,7 +150,7 @@ public class SearchingMethodsTest {
     }
 
     @Test
-    void recursiveBinarySearch_nullHaystack_throwsException() {
+    void recursiveBinarySearch_nullHaystack_throwsNullPointerException() {
         Integer[] myHaystack = null;
         Integer myNeedle = 99;
         assertThrows(NullPointerException.class,

--- a/src/test/java/SearchingMethodsTest.java
+++ b/src/test/java/SearchingMethodsTest.java
@@ -50,62 +50,42 @@ public class SearchingMethodsTest {
         assertEquals(4, SearchingMethods.iterativeLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY));
     }
 
-
     @Test
     void recursiveLinearSearch_nullHaystack_throwsNullPointerException() {
-        Integer[] myHaystack = null;
-        Integer myNeedle = 99;
-        assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
+        assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveLinearSearch(99, null, 0));
+    }
+
+    @Test
+    void recursiveLinearSearch_nullNeedle_returnsSentinel() {
+        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch(null, UNSORTED_ARRAY, 0));
     }
 
     @Test
     void recursiveLinearSearch_mismatchTypes_returnsSentinel() {
-        Integer[] myHaystack = new Integer[10];
-        String myNeedle = "99";
-        assertEquals(-1, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
+        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch("99", UNSORTED_ARRAY, 0));
     }
 
     @Test
     void recursiveLinearSearch_sizeZeroHaystack_returnsSentinel() {
-        Integer[] myHaystack = new Integer[0];
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
+        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch(99, new Integer[0], 0));
     }
 
     @Test
     void recursiveLinearSearch_needleNotWithinHaystack_returnsSentinel() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
+        assertEquals(NOT_FOUND, SearchingMethods.recursiveLinearSearch(NOT_WITHIN_HAYSTACK, UNSORTED_ARRAY, 0));
     }
 
-    @Test
-    void recursiveLinearSearch_needleAtZeroIndex_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 0;
-        assertEquals(0, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
-    }
-
-    @Test
-    void recursiveLinearSearch_needleAtEndOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 98;
-        assertEquals(23, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
-    }
-
-    @Test
-    void recursiveLinearSearch_needleAtMiddleOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 55;
-        assertEquals(15, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
+    @ParameterizedTest
+    @CsvSource({"33,0", "0,14", "90,23"})
+    void recursiveLinearSearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
+        assertEquals(index, SearchingMethods.recursiveLinearSearch(needle, UNSORTED_ARRAY, 0));
     }
 
     @Test
     void recursiveLinearSearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 40;
-        assertEquals(11, SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
+        assertEquals(4, SearchingMethods.recursiveLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY, 0));
     }
+
 
     @Test
     void iterativeBinarySearch_nullHaystack_throwsNullPointerException() {

--- a/src/test/java/SearchingMethodsTest.java
+++ b/src/test/java/SearchingMethodsTest.java
@@ -86,90 +86,70 @@ public class SearchingMethodsTest {
         assertEquals(4, SearchingMethods.recursiveLinearSearch(DUPLICATE_NEEDLE, UNSORTED_ARRAY, 0));
     }
 
-
     @Test
     void iterativeBinarySearch_nullHaystack_throwsNullPointerException() {
-        Integer[] myHaystack = null;
-        Integer myNeedle = 99;
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
+        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(99, null));
+    }
+
+    @Test
+    void iterativeBinarySearch_nullNeedle_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(null, SORTED_ARRAY));
     }
 
     @Test
     void iterativeBinarySearch_sizeZeroHaystack_returnsSentinel() {
-        Integer[] myHaystack = new Integer[0];
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
+        assertEquals(NOT_FOUND, SearchingMethods.iterativeBinarySearch(99, new Integer[0]));
     }
 
     @Test
     void iterativeBinarySearch_needleNotWithinHaystack_returnsSentinel() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
+        assertEquals(NOT_FOUND, SearchingMethods.iterativeBinarySearch(NOT_WITHIN_HAYSTACK, SORTED_ARRAY));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,0", "37,10", "98,23"})
+    void iterativeBinarySearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
+        assertEquals(index, SearchingMethods.iterativeBinarySearch(needle, SORTED_ARRAY));
     }
 
     @Test
-    void iterativeBinarySearch_needleAtZeroIndex_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 0;
-        assertEquals(0, SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
+    void iterativeBinarySearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
+        assertEquals(12, SearchingMethods.iterativeBinarySearch(DUPLICATE_NEEDLE, SORTED_ARRAY));
     }
 
-    @Test
-    void iterativeBinarySearch_needleAtEndOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 98;
-        assertEquals(23, SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
-    }
-
-    @Test
-    void iterativeBinarySearch_needleAtMiddleOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 55;
-        assertEquals(15, SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
-    }
 
     @Test
     void recursiveBinarySearch_nullHaystack_throwsNullPointerException() {
-        Integer[] myHaystack = null;
-        Integer myNeedle = 99;
-        assertThrows(NullPointerException.class,
-                () -> SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
+        SearchingMethods.recursiveBinarySearch(99, null, 0, 0);
+        assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveBinarySearch(99, null, 0, 1));
     }
 
+    @Test
+    void recursiveBinarySearch_nullNeedle_throwsNullPointerException() {
+        assertThrows(NullPointerException.class,
+                () -> SearchingMethods.recursiveBinarySearch(null, SORTED_ARRAY, 0, 1));
+    }
 
     @Test
     void recursiveBinarySearch_sizeZeroHaystack_returnsSentinel() {
-        Integer[] myHaystack = new Integer[0];
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
+        assertEquals(NOT_FOUND, SearchingMethods.recursiveBinarySearch(99, new Integer[0], 0, 0));
     }
 
     @Test
     void recursiveBinarySearch_needleNotWithinHaystack_returnsSentinel() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 99;
-        assertEquals(-1, SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
+        assertEquals(NOT_FOUND,
+                SearchingMethods.recursiveBinarySearch(NOT_WITHIN_HAYSTACK, SORTED_ARRAY, 0, SORTED_ARRAY.length));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,0", "37,10", "98,23"})
+    void recursiveBinarySearch_needleAtZeroIndex_returnsCorrectIndex(Integer needle, int index) {
+        assertEquals(index, SearchingMethods.recursiveBinarySearch(needle, SORTED_ARRAY, 0, SORTED_ARRAY.length));
     }
 
     @Test
-    void recursiveBinarySearch_needleAtZeroIndex_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 0;
-        assertEquals(0, SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
-    }
-
-    @Test
-    void recursiveBinarySearch_needleAtEndOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 98;
-        assertEquals(23, SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
-    }
-
-    @Test
-    void recursiveBinarySearch_needleAtMiddleOfHaystack_returnsCorrectIndex() {
-        Integer[] myHaystack = {0, 4, 8, 12, 18, 25, 31, 33, 36, 35, 37, 40, 40, 40, 49, 55, 61, 62, 63, 74, 81, 89, 90, 98};
-        Integer myNeedle = 55;
-        assertEquals(15, SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
+    void recursiveBinarySearch_multipleEqualNeedles_returnsFirstOccurrenceIndex() {
+        assertEquals(12,
+                SearchingMethods.recursiveBinarySearch(DUPLICATE_NEEDLE, SORTED_ARRAY, 0, SORTED_ARRAY.length));
     }
 }

--- a/src/test/java/SearchingMethodsTest.java
+++ b/src/test/java/SearchingMethodsTest.java
@@ -13,13 +13,6 @@ public class SearchingMethodsTest {
     }
 
     @Test
-    void iterativeLinearSearch_nullNeedle_throwsException() {
-        Integer[] myHaystack = new Integer[99];
-        Integer myNeedle = null;
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeLinearSearch(myNeedle, myHaystack));
-    }
-
-    @Test
     void iterativeLinearSearch_mismatchTypes_returnsSentinel() {
         Integer[] myHaystack = new Integer[0];
         String myNeedle = "99";
@@ -72,13 +65,6 @@ public class SearchingMethodsTest {
     void recursiveLinearSearch_nullHaystack_throwsException() {
         Integer[] myHaystack = null;
         Integer myNeedle = 99;
-        assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
-    }
-
-    @Test
-    void recursiveLinearSearch_nullNeedle_throwsException() {
-        Integer[] myHaystack = new Integer[99];
-        Integer myNeedle = null;
         assertThrows(NullPointerException.class, () -> SearchingMethods.recursiveLinearSearch(myNeedle, myHaystack, 0));
     }
 

--- a/src/test/java/SearchingMethodsTest.java
+++ b/src/test/java/SearchingMethodsTest.java
@@ -125,13 +125,6 @@ public class SearchingMethodsTest {
     }
 
     @Test
-    void iterativeBinarySearch_nullNeedle_throwsException() {
-        Integer[] myHaystack = new Integer[99];
-        Integer myNeedle = null;
-        assertThrows(NullPointerException.class, () -> SearchingMethods.iterativeBinarySearch(myNeedle, myHaystack));
-    }
-
-    @Test
     void iterativeBinarySearch_sizeZeroHaystack_returnsSentinel() {
         Integer[] myHaystack = new Integer[0];
         Integer myNeedle = 99;
@@ -174,13 +167,6 @@ public class SearchingMethodsTest {
                 () -> SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
     }
 
-    @Test
-    void recursiveBinarySearch_nullNeedle_throwsException() {
-        Integer[] myHaystack = new Integer[99];
-        Integer myNeedle = null;
-        assertThrows(NullPointerException.class,
-                () -> SearchingMethods.recursiveBinarySearch(myNeedle, myHaystack, 0, myHaystack.length));
-    }
 
     @Test
     void recursiveBinarySearch_sizeZeroHaystack_returnsSentinel() {


### PR DESCRIPTION
### What
Clean up the code and tests

### Testing
:+1:

### Additional Notes
1. The type mismatch tests were inadmissible for the binary search.
2. I abused the `recursiveBinarySearch` call for the `null` tests by passing arguments to suggest there was a size. 
3. I opted to add a `NOT_FOUND` constant to the test class as I still think it was nicer than just `-1`.
4. I _could_ change the binary search methods to behave the same way as the linear with a `null` needle, but idk, meh. 
