### PR TITLE
:bug: :mortar_board: Country Catalogue Assignment --- Fix typesetting (missing space) :microscope: 

### DIFF
--- a/src/site/assignments/country-catalogue/country-catalogue.rst
+++ b/src/site/assignments/country-catalogue/country-catalogue.rst
@@ -101,7 +101,7 @@ instances of the ``Country`` class.
 #. Write a method to calculate and return the population density (``population/area``)
 
     * With floating point numbers (doubles included), division by zero results in a special value --- ``Infinity``
-    * If this method is called on a ``Country`` object with an ``area``of zero, it should return ``Infinity``
+    * If this method is called on a ``Country`` object with an ``area`` of zero, it should return ``Infinity``
     * In other words, this method should not perform any special check for ``area`` being zero
 
 


### PR DESCRIPTION
### What
Add a space between the verbatim `area` and the word "of" 

### Why
Fixes the typesetting. 
