### PR TITLE
:lipstick: :technologist: Bag Implementations --- Change `equals` and `hashCode` to use iterators

### DIFF
--- a/src/main/java/ArrayIndexedBag.java
+++ b/src/main/java/ArrayIndexedBag.java
@@ -204,8 +204,8 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
         if (this.size() != that.size()) {
             return false;
         }
-        for (int i = 0; i < this.size(); i++) {
-            if (this.count(this.bag[i]) != that.count(this.bag[i])) {
+        for (T element : this) {
+            if (this.count(element) != that.count(element)) {
                 return false;
             }
         }
@@ -215,8 +215,8 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
     @Override
     public int hashCode() {
         int result = Objects.hash(rear);
-        for (int i = 0; i < size(); i++) {
-            result += Objects.hashCode(bag[i]);
+        for (T element : this) {
+            result += Objects.hashCode(element);
         }
         return result;
     }

--- a/src/main/java/ArraySortedBag.java
+++ b/src/main/java/ArraySortedBag.java
@@ -224,8 +224,8 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
         if (this.size() != that.size()) {
             return false;
         }
-        for (int i = 0; i < this.size(); i++) {
-            if (this.count(this.bag[i]) != that.count(this.bag[i])) {
+        for (T element : this) {
+            if (this.count(element) != that.count(element)) {
                 return false;
             }
         }
@@ -235,8 +235,8 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
     @Override
     public int hashCode() {
         int result = Objects.hash(rear);
-        for (int i = 0; i < size(); i++) {
-            result += Objects.hashCode(bag[i]);
+        for (T element : this) {
+            result += Objects.hashCode(element);
         }
         return result;
     }


### PR DESCRIPTION
### What
- Change `equals` in `ArrayIndexedBag` to use iterator
- Change `hashCode` in `ArrayIndexedBag` to use iterator
- Change `equals` in `ArraySortedBag` to use iterator
- Change `hashCode` in `ArraySortedBag` to use iterator


### Testing
:+1: 

This change does not impact any `literalinclude` in the topics 
