### PR TITLE
:new: :technologist: `ArraySortedBagTest` --- Add tests for first and last leaving collection unchanged

### DIFF
--- a/src/test/java/ArraySortedBagTest.java
+++ b/src/test/java/ArraySortedBagTest.java
@@ -16,10 +16,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ArraySortedBagTest {
     private ArraySortedBag<Integer> classUnderTest;
+    private ArraySortedBag<Integer> preState;
 
     @BeforeEach
     void createSortedBag() {
         classUnderTest = new ArraySortedBag<>();
+        preState = new ArraySortedBag<>();
     }
 
     @Nested
@@ -102,6 +104,7 @@ public class ArraySortedBagTest {
             @BeforeEach
             void addSingleton() {
                 classUnderTest.add(10);
+                preState.add(10);
             }
 
             @Test
@@ -227,6 +230,10 @@ public class ArraySortedBagTest {
                     classUnderTest.add(30);
                     classUnderTest.add(40);
                     classUnderTest.add(50);
+                    preState.add(20);
+                    preState.add(30);
+                    preState.add(40);
+                    preState.add(50);
                 }
 
                 @Test
@@ -351,6 +358,11 @@ public class ArraySortedBagTest {
                     classUnderTest.add(20);
                     classUnderTest.add(10);
                     classUnderTest.add(20);
+                    preState.add(20);
+                    preState.add(10);
+                    preState.add(20);
+                    preState.add(10);
+                    preState.add(20);
                 }
 
                 @Test

--- a/src/test/java/ArraySortedBagTest.java
+++ b/src/test/java/ArraySortedBagTest.java
@@ -167,8 +167,20 @@ public class ArraySortedBagTest {
             }
 
             @Test
+            void first_singleton_unchanged() {
+                classUnderTest.first();
+                assertEquals(preState, classUnderTest);
+            }
+
+            @Test
             void last_singleton_returnsElement() {
                 assertEquals(10, classUnderTest.last());
+            }
+
+            @Test
+            void last_singleton_unchanged() {
+                classUnderTest.last();
+                assertEquals(preState, classUnderTest);
             }
 
             @Test
@@ -298,8 +310,20 @@ public class ArraySortedBagTest {
                 }
 
                 @Test
+                void first_many_unchanged() {
+                    classUnderTest.first();
+                    assertEquals(preState, classUnderTest);
+                }
+
+                @Test
                 void last_many_returnsElement() {
                     assertEquals(50, classUnderTest.last());
+                }
+
+                @Test
+                void last_many_unchanged() {
+                    classUnderTest.last();
+                    assertEquals(preState, classUnderTest);
                 }
 
                 @ParameterizedTest


### PR DESCRIPTION
### What
Add unit tests for checking if the collection is unchanged when calling first & last

### Why
They're missing. Feels like they should be checked since they are the alternative to `removeFirst` and `removeLast`. 

### Testing
:+1:

### Additional Notes
There is no similar change to the indexed bag tests since there isn't a similar thing to first & last. The most similar would be `get`, but, idk, feels like checking unchanged on that isn't really necessary when compared to this since `removeFirst` explicitly removes the first and returns it and `first` is just returning it, so it's important to check that it's not changed. 
