### PR TITLE
:bug: :mortar_board: Array queue topic --- Fix playing code at end :microscope: 

### DIFF
--- a/src/site/topics/queues/array-queue.rst
+++ b/src/site/topics/queues/array-queue.rst
@@ -483,6 +483,6 @@ Playing Code
 
 * If everything was done correctly, the following code from ``PlayingArrayQueue`` should work
 
-.. literalinclude:: /../main/java/PlayingLinkedQueue.java
+.. literalinclude:: /../main/java/PlayingArrayQueue.java
    :language: java
    :linenos:


### PR DESCRIPTION
### What
Change the playing code to be the `PlayingArrayQueue` instead of `PlayingLinkedQueue` 

### Why
Because this is for the `ArrayQueue` 

### Testing
:+1: built local, looks good 