### PR TITLE
:telescope: :technologist: `ArraySortedBag` --- Set "empty" array index to null after `removeLast` :telescope: 

### DIFF
--- a/src/main/java/ArraySortedBag.java
+++ b/src/main/java/ArraySortedBag.java
@@ -144,6 +144,7 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
             throw new NoSuchElementException("Empty bag");
         }
         T returnElement = bag[rear - 1];
+        bag[rear - 1] = null;
         rear--;
         return returnElement;
     }


### PR DESCRIPTION
### What
Have the index in the array set to null when removing last 

### Why
Mostly consistency. All other cases in the class would set the removed element's old index to null. Further, the data is not supposed to be there anymore anyways, so might as well yeet it.  

### Testing
:+1:

### Additional Notes
Someone spotted it in lab and asked about it.
