### PR TITLE
:mortar_board: Bag Implementations Topic --- Note that `indexOf` may throw an exception

### DIFF
--- a/src/site/topics/bags/bag-implementations.rst
+++ b/src/site/topics/bags/bag-implementations.rst
@@ -154,7 +154,7 @@ Remove
 
 
 * The ``remove(T element)`` method delegates to the ``remove(int index)`` for ease and code/logic reuse
-
+* Note that ``indexOf`` will throw an exception if the element does not exist within the bag 
 
 
 ArraySortedBag


### PR DESCRIPTION
### What
Mention that `indexOf` may throw an exception if the element does not exist. 

### Why
The `indexOf` method is not discussed in the course notes, and although it is mentioned in a comment, having it spelled out is good. Someone asked about it during lecture today. 

This _could_ be addressed by explicitly talking about `indexOf` in the notes, but (a) it has been discussed before earlier in the semester, and (b) it would require talking about `contains` and then `find` and then iterators since the `find` uses iterators. This is ideally avoided here since iterators are discussed in the subsequent topic. 