### PR TITLE
:bug: :mortar_board: Iterator Topic --- Fix error in equals

### DIFF
--- a/src/site/topics/iterators/iterators.rst
+++ b/src/site/topics/iterators/iterators.rst
@@ -356,7 +356,10 @@ Equality of Stacks (and Queues)
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof Stack)) {
             return false;
         }
         Stack<?> that = (Stack<?>) o;


### PR DESCRIPTION
### What
Fix the more general stack equality check example

`this.getClass() != other.getClass()` -> `other instanceof Stack` 


### Why
There's a bug --- it doesn't check if the type is a Stack. Instead it checked if they were the same class. 

### Testing
:+1: built local, looks good. 
