### PR TITLE
:bug: :mortar_board: Trees ADT Topic --- Mention height :microscope: 

### DIFF
--- a/src/site/topics/trees/tree-adt.rst
+++ b/src/site/topics/trees/tree-adt.rst
@@ -163,7 +163,7 @@ Properties
 
     * The path length between the two emphasized nodes is three (``3``)
     * The height of this tree is three (``3``)
-    * A tree with only a root is zero (``0``)
+    * A tree with only a root has a height of zero (``0``)
     * The height of an empty tree is negative one (``-1``)
 
 


### PR DESCRIPTION
### What
Say that it's the HEIGHT of the tree that is zero

### Why
It doesn't say height and reads weird. 