### PR TITLE
:bug: :mortar_board: Linked Binary Search Tree Topic --- Remove extra lines from code example :microscope: 

### DIFF
--- a/src/site/topics/trees/linked-binary-search-trees.rst
+++ b/src/site/topics/trees/linked-binary-search-trees.rst
@@ -13,7 +13,7 @@ Constructors
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 1-20
+    :lines: 1-13
 
 
 * Like the other implementations, this class ``implements`` the interface


### PR DESCRIPTION
### What
Remove the extra lines from the code example for the constructor and fields and whatnot. 

### Why
Too many

### Testing
:+1: built local, looks good. 

### Additional Notes
I'm guessing this happened when I removed the other constructor from the class. 
