### PR TITLE
:mortar_board: Labs --- Add remaining to index :microscope: 

### DIFF
--- a/src/site/index.rst
+++ b/src/site/index.rst
@@ -110,7 +110,8 @@ Office Hours
     labs/recursion/recursion
     labs/binary-trees/binary-trees
     labs/heaps/heaps
-    labs/sorting/sorting
+    labs/sorting/sorting-basic
+    labs/sorting/sorting-recursive
 
 
 .. toctree::

--- a/src/site/index.rst
+++ b/src/site/index.rst
@@ -109,6 +109,8 @@ Office Hours
     labs/iterators/iterators
     labs/recursion/recursion
     labs/binary-trees/binary-trees
+    labs/heaps/heaps
+    labs/sorting/sorting
 
 
 .. toctree::


### PR DESCRIPTION
### What
Add the remaining labs to the index

### Why
So they can access them. 

### Testing
:+1: built local, looks good. 

### Additional Notes
There's only 1 week of labs remaining, so obviously they can't do all 3. That said, why not add them as examples to study from?

In fact, this got me thinking, maybe for future years I have a few more labs and just list them all and then students have a little choice in what labs they do during lab time. They'd still follow along with the content, but perhaps hit some topics that just were not in labs before. 

Further, keen students are always asking for more practice stuff, so this could fill that gap.