### PR TITLE
:bug: :technologist: Linked Binary Search Tree --- Fix general remove exception for non exist item

### DIFF
--- a/src/main/java/LinkedBinarySearchTree.java
+++ b/src/main/java/LinkedBinarySearchTree.java
@@ -68,7 +68,7 @@ public class LinkedBinarySearchTree<T extends Comparable<? super T>> implements 
      */
     private T remove(T element, Node<T> parent, Node<T> current) {
         if (current == null) {
-            throw new NoSuchElementException("Empty Tree");
+            throw new NoSuchElementException(Objects.toString(element));
         }
         int comparison = current.getData().compareTo(element);
         if (comparison == 0) {


### PR DESCRIPTION
### What
Update the exception message to just say the element that was being looked for 

### Why
It said "empty tree" which wasn't the best message. Someone could argue that _technically_ it's a correct message in that the subtree is empty, but still, the message is better this way. 

### How
Make it return the string of the element being looked for like the other data structures. 

### Testing
:+1:

### Additional Notes
Noticed during lecture. 