### PR TITLE
:mortar_board: :technologist: Country Catalogue --- Remove returns `false`

### DIFF
--- a/src/site/assignments/country-catalogue/Assignment1/test/CountryCatalogueTest.java
+++ b/src/site/assignments/country-catalogue/Assignment1/test/CountryCatalogueTest.java
@@ -36,8 +36,8 @@ class CountryCatalogueTest {
         }
 
         @Test
-        void remove_empty_throwsNoSuchElementException() {
-            assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(NONEXISTENT_COUNTRY));
+        void remove_empty_returnsFalse() {
+            assertFalse(classUnderTest.remove(NONEXISTENT_COUNTRY));
         }
 
         @Test
@@ -128,8 +128,8 @@ class CountryCatalogueTest {
             }
 
             @Test
-            void remove_nonexistentCountry_throwsNoSuchElementException() {
-                assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(NONEXISTENT_COUNTRY));
+            void remove_nonexistentCountry_returnsFalse() {
+                assertFalse(classUnderTest.remove(NONEXISTENT_COUNTRY));
             }
 
             @Test
@@ -269,8 +269,8 @@ class CountryCatalogueTest {
                 }
 
                 @Test
-                void remove_nonexistentCountry_throwsNoSuchElementException() {
-                    assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(NONEXISTENT_COUNTRY));
+                void remove_nonexistentCountry_returnsFalse() {
+                    assertFalse(classUnderTest.remove(NONEXISTENT_COUNTRY));
                 }
 
                 @ParameterizedTest

--- a/src/site/assignments/country-catalogue/country-catalogue.rst
+++ b/src/site/assignments/country-catalogue/country-catalogue.rst
@@ -177,7 +177,11 @@ The class will also have two static constants
 
     * This method takes the ``Country`` object to be removed as a parameter
     * This method returns a ``boolean`` indicating if the remove was successful
-    * This method throws a ``NoSuchElementException`` if no matching ``Country`` object exists
+
+        * Returns ``true`` if the remove was successful
+        * Returns ``false`` if the remove was unsuccessful; if the element to be removed does not exist
+
+
     * If more than one matching ``Country`` object exists, only remove the first occurrence
     * If a ``Country`` object is removed, the order of the remaining ``Country`` objects must remain unchanged
 


### PR DESCRIPTION
### Related Issues or PRs
#899 
Also the PR in the private repo 

### What
Change the assignment such that removing an element that does not exist now returns `false` instead of throwing an exception
- Update the unit tests
- Update the assignment description

### Why
More consistent with java collections 

### Additional Notes
This is jumping the gun as the PR in the private repo is yet to be approved. This PR will not be merged until the corresponding private repo one is merged. 
