### PR TITLE
:mortar_board: :technologist: :lipstick: Contact list --- Remove returns `false` when not successful 

### DIFF
--- a/src/main/java/ContactList.java
+++ b/src/main/java/ContactList.java
@@ -125,18 +125,16 @@ public class ContactList {
     }
 
     /**
-     * Removes the specified Friend object from the collection. If no such Friend object exists, a
-     * NoSuchElementException is thrown. The removed object is removed from the collection by being replaced in the
-     * collection with the Friend object at the end of the collection. This, remove does not preserve the order of
-     * the Friend objects within the collection.
+     * Removes the specified Friend object from the collection. The removed object is removed from the collection by
+     * being replaced in the  collection with the Friend object at the end of the collection. This, remove does not
+     * preserve the order of the Friend objects within the collection.
      *
      * @param friend Friend object to remove from the collection.
      * @return True if the object was successfully removed, false otherwise.
-     * @throws NoSuchElementException If the Friend object does not exist within the collection.
      */
     public boolean remove(Friend friend) {
         if (!contains(friend)) {
-            throw new NoSuchElementException(Objects.toString(friend));
+            return false;
         }
         int removeIndex = find(friend);
         // Although it is possible that the element being removed is replaced with itself, which happens when it is the

--- a/src/site/topics/objects-review/data-structures-review.rst
+++ b/src/site/topics/objects-review/data-structures-review.rst
@@ -226,7 +226,7 @@ Setting Fields and Writing the Constructor
 .. literalinclude:: /../main/java/ContactList.java
     :language: java
     :lineno-match:
-    :lines: 127-151
+    :lines: 127-149
 
 
 * Remove first checks if the ``Friend`` object exists within the ``ContactList``
@@ -265,7 +265,7 @@ Setting Fields and Writing the Constructor
 .. literalinclude:: /../main/java/ContactList.java
     :language: java
     :lineno-match:
-    :lines: 153-159
+    :lines: 151-157
 
 
 * Here, simply create a new empty array and set the size to ``0``
@@ -280,7 +280,7 @@ Setting Fields and Writing the Constructor
 .. literalinclude:: /../main/java/ContactList.java
     :language: java
     :lineno-match:
-    :lines: 161-167
+    :lines: 159-165
 
 
 * ``isEmpty`` returns a ``boolean`` indicating if the ``ContactList`` is empty or not
@@ -315,7 +315,7 @@ Setting Fields and Writing the Constructor
 .. literalinclude:: /../main/java/ContactList.java
     :language: java
     :lineno-match:
-    :lines: 169-183
+    :lines: 167-181
     :emphasize-lines: 11
 
 
@@ -333,7 +333,7 @@ Setting Fields and Writing the Constructor
 .. literalinclude:: /../main/java/ContactList.java
     :language: java
     :lineno-match:
-    :lines: 185-202
+    :lines: 183-200
 
 * Here, ``Arrays.equals`` is used to check the equality on the array
 
@@ -344,7 +344,7 @@ Setting Fields and Writing the Constructor
 .. literalinclude:: /../main/java/ContactList.java
     :language: java
     :lineno-match:
-    :lines: 204-211
+    :lines: 202-209
 
 
 * Above is an example of the ``hashCode`` method for the ``ContactList`` class

--- a/src/test/java/ContactListTest.java
+++ b/src/test/java/ContactListTest.java
@@ -56,8 +56,8 @@ public class ContactListTest {
         }
 
         @Test
-        void remove_empty_throwsNoSuchElementException() {
-            assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(NONEXISTENT_FRIEND));
+        void remove_empty_returnsFalse() {
+            assertFalse(classUnderTest.remove(NONEXISTENT_FRIEND));
         }
 
         @Test
@@ -147,8 +147,8 @@ public class ContactListTest {
             }
 
             @Test
-            void remove_nonexistentFriend_throwsNoSuchElementException() {
-                assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(NONEXISTENT_FRIEND));
+            void remove_nonexistentFriend_returnsFalse() {
+                assertFalse(classUnderTest.remove(NONEXISTENT_FRIEND));
             }
 
             @Test
@@ -252,8 +252,8 @@ public class ContactListTest {
                 }
 
                 @Test
-                void remove_nonexistentFriend_throwsNoSuchElementException() {
-                    assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(NONEXISTENT_FRIEND));
+                void remove_nonexistentFriend_returnsFalse() {
+                    assertFalse(classUnderTest.remove(NONEXISTENT_FRIEND));
                 }
 
                 @Test


### PR DESCRIPTION
### Related Issues or PRs
#899 

### What
Have the contact list example return false when no such element exists instead of throwing exception 

### Why
aligns with java collections 

### Testing
:+1: 

### Additional Notes
Im choosing to continue to do this in separate PRs instead of one larger one since there is some tedium to them given the line number issue (#479). 
