### PR TITLE
:mortar_board: :technologist: :lipstick:  Bag implementations --- Remove method returns `false`

### DIFF
--- a/src/main/java/ArrayIndexedBag.java
+++ b/src/main/java/ArrayIndexedBag.java
@@ -130,10 +130,9 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
 
     @Override
     public boolean remove(T element) {
-        if (isEmpty()) {
-            throw new NoSuchElementException("Empty bag");
+        if (!contains(element)) {
+            return false;
         }
-        // If indexOf throws an exception, this method propagates it
         int removeIndex = indexOf(element);
         remove(removeIndex);
         return true;

--- a/src/main/java/ArraySortedBag.java
+++ b/src/main/java/ArraySortedBag.java
@@ -112,16 +112,12 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
         return true;
     }
 
-
     @Override
     public boolean remove(T element) {
-        if (isEmpty()) {
-            throw new NoSuchElementException("Empty bag");
+        if (!contains(element)) {
+            return false;
         }
         int index = find(element);
-        if (index == NOT_FOUND) {
-            throw new NoSuchElementException(Objects.toString(element));
-        }
         shiftLeft(index);
         rear--;
         return true;

--- a/src/main/java/Bag.java
+++ b/src/main/java/Bag.java
@@ -1,5 +1,4 @@
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 /**
  * A bag is a linear data structure. Bags have no defined ordering. Elements can be added and removed from a bag.
@@ -21,7 +20,6 @@ public interface Bag<T> extends Iterable<T> {
      *
      * @param element Element to be removed from the bag.
      * @return True if the element was removed successfully, false otherwise.
-     * @throws NoSuchElementException If the provided element does not exist within the bag.
      */
     boolean remove(T element);
 

--- a/src/main/java/SortedBag.java
+++ b/src/main/java/SortedBag.java
@@ -23,7 +23,6 @@ public interface SortedBag<T extends Comparable<? super T>> extends Bag<T> {
      *
      * @param element Element to be removed from the bag.
      * @return True if the element was removed successfully, false otherwise.
-     * @throws NoSuchElementException If the sorted bag is empty or the provided element does not exist within the bag.
      */
     @Override
     boolean remove(T element);

--- a/src/site/topics/bags/bag-implementations.rst
+++ b/src/site/topics/bags/bag-implementations.rst
@@ -111,7 +111,7 @@ Iterator Method
 .. literalinclude:: /../main/java/ArrayIndexedBag.java
     :language: java
     :lineno-match:
-    :lines: 176-179
+    :lines: 175-178
 
 
 * All this method does is create an instance of an ``ArrayIterator`` and return it
@@ -150,7 +150,7 @@ Remove
 .. literalinclude:: /../main/java/ArrayIndexedBag.java
     :language: java
     :lineno-match:
-    :lines: 120-140
+    :lines: 120-139
 
 
 * The ``remove(T element)`` method delegates to the ``remove(int index)`` for ease and code/logic reuse

--- a/src/test/java/ArrayIndexedBagTest.java
+++ b/src/test/java/ArrayIndexedBagTest.java
@@ -74,8 +74,8 @@ public class ArrayIndexedBagTest {
         }
 
         @Test
-        void remove_empty_throwsNoSuchElementException() {
-            assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(Integer.valueOf(0)));
+        void remove_empty_returnsFalse() {
+            assertFalse(classUnderTest.remove(Integer.valueOf(0)));
         }
 
         @Test
@@ -221,8 +221,8 @@ public class ArrayIndexedBagTest {
             }
 
             @Test
-            void remove_nonexistentElement_throwsNoSuchElementException() {
-                assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(Integer.valueOf(0)));
+            void remove_nonexistentElement_returnsFalse() {
+                assertFalse(classUnderTest.remove(Integer.valueOf(0)));
             }
 
             @Test
@@ -393,8 +393,8 @@ public class ArrayIndexedBagTest {
                 }
 
                 @Test
-                void remove_nonexistentElement_throwsNoSuchElementException() {
-                    assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(Integer.valueOf(0)));
+                void remove_nonexistentElement_returnsFalse() {
+                    assertFalse(classUnderTest.remove(Integer.valueOf(0)));
                 }
 
                 @ParameterizedTest

--- a/src/test/java/ArraySortedBagTest.java
+++ b/src/test/java/ArraySortedBagTest.java
@@ -33,8 +33,8 @@ public class ArraySortedBagTest {
         }
 
         @Test
-        void remove_empty_throwsNoSuchElementException() {
-            assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(0));
+        void remove_empty_returnsFalse() {
+            assertFalse(classUnderTest.remove(0));
         }
 
         @Test
@@ -135,8 +135,8 @@ public class ArraySortedBagTest {
             }
 
             @Test
-            void remove_nonexistentElement_throwsNoSuchElementException() {
-                assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(0));
+            void remove_nonexistentElement_returnsFalse() {
+                assertFalse(classUnderTest.remove(0));
             }
 
             @Test
@@ -278,8 +278,8 @@ public class ArraySortedBagTest {
                 }
 
                 @Test
-                void remove_nonexistentElement_throwsNoSuchElementException() {
-                    assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(0));
+                void remove_nonexistentElement_returnsFalse() {
+                    assertFalse(classUnderTest.remove(0));
                 }
 
                 @Test


### PR DESCRIPTION
### Related Issues or PRs
#899 

### What
Have it such that the bag implementations return `false` when the element does not exist within the bag. 

### Why
Consistency with java collections 

### How
This one has a little more nuance since before the remove could throw two exceptions: one for when the bag was empty and one for when the element did not exist. I opted to just return false in both cases. This made the method slightly simpler too. 

This got kinda' weird though since, for example, in the sorted bag, exceptions are still thrown if the bag is empty when calling remove first/last. My justification for this is, the general remove returns a boolean, so the boolean tells us what we need to know on the success/fail of the method call. For the remove first/last, they return an actual element, so the exception still makes sense here (sure I could return `null` if its empty, but that seems bad). 

### Testing
:+1: 
