### PR TITLE
:mortar_board: :technologist: :lipstick: Trees --- Remove method returns `false` 

### DIFF
--- a/src/main/java/BinarySearchTree.java
+++ b/src/main/java/BinarySearchTree.java
@@ -27,7 +27,6 @@ public interface BinarySearchTree<T extends Comparable<? super T>> extends Binar
      *
      * @param element Element to be removed from the binary search tree.
      * @return True if the element was removed successfully, false otherwise.
-     * @throws NoSuchElementException If the provided element does not exist within the binary search tree.
      */
     @Override
     boolean remove(T element);

--- a/src/main/java/BinaryTree.java
+++ b/src/main/java/BinaryTree.java
@@ -1,5 +1,4 @@
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 
 /**
@@ -24,7 +23,6 @@ public interface BinaryTree<T> extends Iterable<T> {
      *
      * @param element Element to be removed from the binary tree.
      * @return True if the element was removed successfully, false otherwise.
-     * @throws NoSuchElementException If the provided element does not exist within the binary tree.
      */
     boolean remove(T element);
 

--- a/src/main/java/LinkedBinarySearchTree.java
+++ b/src/main/java/LinkedBinarySearchTree.java
@@ -65,9 +65,6 @@ public class LinkedBinarySearchTree<T extends Comparable<? super T>> implements 
      * @return The element being removed
      */
     private T remove(T element, Node<T> parent, Node<T> current) {
-        if (current == null) {
-            throw new NoSuchElementException(Objects.toString(element));
-        }
         int comparison = current.getData().compareTo(element);
         if (comparison == 0) {
             if (parent.getData().compareTo(current.getData()) > 0) {

--- a/src/main/java/LinkedBinarySearchTree.java
+++ b/src/main/java/LinkedBinarySearchTree.java
@@ -41,8 +41,8 @@ public class LinkedBinarySearchTree<T extends Comparable<? super T>> implements 
 
     @Override
     public boolean remove(T element) {
-        if (isEmpty()) {
-            throw new NoSuchElementException("Empty Tree");
+        if (!contains(element)) {
+            return false;
         }
         int comparison = root.getData().compareTo(element);
         if (comparison == 0) {

--- a/src/site/topics/trees/linked-binary-search-trees.rst
+++ b/src/site/topics/trees/linked-binary-search-trees.rst
@@ -34,7 +34,7 @@ Static Node Class
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 445-489
+    :lines: 442-486
 
 * Things of note for this node class
 
@@ -66,7 +66,7 @@ Minimum & Maximum
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 189-226
+    :lines: 186-223
 
 
 * Fortunately the minimum and maximum methods are simple
@@ -92,7 +92,7 @@ Remove Minimum
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 128-157
+    :lines: 125-154
 
 
 * Above are two methods that work together to remove the minimum value
@@ -133,7 +133,7 @@ Remove Maximum
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 159-187
+    :lines: 156-184
 
 
 * ``removeMax`` is similar to the public ``removeMin`` method
@@ -170,7 +170,7 @@ General Remove
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 59-84
+    :lines: 59-81
 
 
 * The private ``remove`` is basically doing a binary search through the tree looking for the value to be removed
@@ -186,7 +186,7 @@ General Remove
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 86-126
+    :lines: 83-123
 
 
 * ``findReplacementNode`` looks rather intimidating at first, but if studied carefully, it is actually rather simple
@@ -241,7 +241,7 @@ General Remove
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 228-254
+    :lines: 225-251
 
 
 * See the above method called ``contains`` and the recursive ``binarySearch`` method
@@ -261,7 +261,7 @@ General Remove
 .. literalinclude:: /../main/java/LinkedBinarySearchTree.java
     :language: java
     :lineno-match:
-    :lines: 256-284
+    :lines: 253-281
     :emphasize-lines: 21, 22, 23
 
 

--- a/src/test/java/LinkedBinarySearchTreeTest.java
+++ b/src/test/java/LinkedBinarySearchTreeTest.java
@@ -32,8 +32,8 @@ public class LinkedBinarySearchTreeTest {
         }
 
         @Test
-        void remove_empty_throwsNoSuchElementException() {
-            assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(11));
+        void remove_empty_returnsFalse() {
+            assertFalse(classUnderTest.remove(11));
         }
 
         @Test
@@ -157,8 +157,8 @@ public class LinkedBinarySearchTreeTest {
             }
 
             @Test
-            void remove_nonExistentElement_throwsNoSuchElementException() {
-                assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(11));
+            void remove_nonExistentElement_returnsFalse() {
+                assertFalse(classUnderTest.remove(11));
             }
 
             @Test
@@ -345,8 +345,8 @@ public class LinkedBinarySearchTreeTest {
                 }
 
                 @Test
-                void remove_nonExistentElement_throwsNoSuchElementException() {
-                    assertThrows(NoSuchElementException.class, () -> classUnderTest.remove(11));
+                void remove_nonExistentElement_returnsFalse() {
+                    assertFalse(classUnderTest.remove(11));
                 }
 
                 @Test


### PR DESCRIPTION
### Related Issues or PRs
#899 (this should be the last of them related to this one) 

### What
Make it such that removing a non-existing element from a tree has the method return false instead of throwing an exception. 

### Why
Consistency with java collections 

### How
Similar to #938 and the exceptions being thrown if the tree is empty in the other remove methods. 

I originally kept the exception thrown in the private `remove` method if the current node is ever null, which was originally what was propagated up to the public remove if the element did not exist. I thought it may make the code more clear for the students to check that case, but upon further thought, I think it may be more confusing to keep if it's kinda' useless. 


### Testing
:+1: 
