### PR TITLE
:lipstick: :telescope: :technologist: Linked BST --- Update hashcode 

### DIFF
--- a/src/main/java/LinkedBinarySearchTree.java
+++ b/src/main/java/LinkedBinarySearchTree.java
@@ -437,7 +437,7 @@ public class LinkedBinarySearchTree<T extends Comparable<? super T>> implements 
     public int hashCode() {
         int result = Objects.hash(size);
         for (T element : this) {
-            result += Objects.hashCode(element);
+            result = result * 97 + Objects.hashCode(element);
         }
         return result;
     }


### PR DESCRIPTION
### Related Issues or PRs
#480

### What
Update the hashCode method such that it always multiples the current hash by a prime before addinng a new elements hash

### Why
Better this way 

### Testing
:+1: 

### Additional Notes
Currently the only unchanged ones (RE #480) are the bag ones because they get weird as the order of the elements for an equality check does not matter. Throwing primes at the hash when looping over the collection would break things. 

