### PR TITLE
:lipstick: Figures --- Use `figure` instead of `image` :microscope: 

### DIFF
--- a/src/site/topics/trees/binary-trees.rst
+++ b/src/site/topics/trees/binary-trees.rst
@@ -236,9 +236,11 @@ Iterative Pre/In/Post-Order
 Traversal Analysis
 ------------------
 
-.. image:: binary_tree_example.png
+.. figure:: binary_tree_example.png
    :width: 500 px
    :align: center
+
+   A nonlinear linked structure --- a binary tree.
 
 
 * Consider a binary tree with :math:`n` nodes

--- a/src/site/topics/trees/tree-adt.rst
+++ b/src/site/topics/trees/tree-adt.rst
@@ -168,7 +168,7 @@ Properties
 
 
 
-.. image:: tree_levels.png
+.. figure:: tree_levels.png
    :width: 500 px
    :align: center
 


### PR DESCRIPTION
### Related Issues or PRs
~Part of~
Closes #621

### What
Remove all uses of rst `image::` and replacve with `figure`

### Why
Figure is better

### Testing
:+1: 

### Additional Notes
There were only 2 I had missed from last year. Found them with grep. 
