### PR TITLE
🔭 💄 🎓 Javadoc comments --- Remove periods

### DIFF
--- a/src/main/java/ArrayIndexedBag.java
+++ b/src/main/java/ArrayIndexedBag.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * Implementation of an IndexedBag with an array as the container. The array container will automatically "grow" to
  * accommodate adding beyond the initial capacity.
  *
- * @param <T> Type of elements that are to be in the IndexedBag.
+ * @param <T> Type of elements that are to be in the IndexedBag
  */
 public class ArrayIndexedBag<T> implements IndexedBag<T> {
 
@@ -28,7 +28,7 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
     /**
      * Create an empty ArrayIndexedBag with the specified capacity.
      *
-     * @param initialCapacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array
      */
     @SuppressWarnings("unchecked")
     public ArrayIndexedBag(int initialCapacity) {
@@ -43,7 +43,7 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
      * Shifts elements in an array down (towards index 0) to the starting index specified. The element at the starting
      * index will be overwritten.
      *
-     * @param start Index of element to be overwritten and where shifting moves down to.
+     * @param start Index of element to be overwritten and where shifting moves down to
      */
     private void shiftLeft(int start) {
         for (int i = start; i < rear - 1; i++) {
@@ -57,7 +57,7 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
      * at the specified starting index will be open. This method assumes there is room in the array to facilitate the
      * shifting.
      *
-     * @param start Index of where the array has a new open location and where shifting moves up from.
+     * @param start Index of where the array has a new open location and where shifting moves up from
      */
     private void shiftRight(int start) {
         for (int i = rear; i > start; i--) {
@@ -71,8 +71,8 @@ public class ArrayIndexedBag<T> implements IndexedBag<T> {
      * Find and return the index of a given target element within the collection. If no such element exists within the
      * collection, a sentinel value of -1 (NOT_FOUND constant) is returned.
      *
-     * @param element Element to find the index of.
-     * @return Index of the target element within the collection, or -1 (NOT_FOUND constant) if no such element exists.
+     * @param element Element to find the index of
+     * @return Index of the target element within the collection, or -1 (NOT_FOUND constant) if no such element exists
      */
     private int find(T element) {
         int searchIndex = 0;

--- a/src/main/java/ArrayQueue.java
+++ b/src/main/java/ArrayQueue.java
@@ -5,7 +5,7 @@ import java.util.Objects;
  * Implementation of a queue with an array as the container. The array container will automatically "grow" to
  * accommodate adding beyond the initial capacity.
  *
- * @param <T> Type of elements that are to be in the queue.
+ * @param <T> Type of elements that are to be in the queue
  */
 public class ArrayQueue<T> implements Queue<T> {
 
@@ -25,7 +25,7 @@ public class ArrayQueue<T> implements Queue<T> {
     /**
      * Create an empty ArrayQueue with the specified capacity.
      *
-     * @param initialCapacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array
      */
     @SuppressWarnings("unchecked")
     public ArrayQueue(int initialCapacity) {

--- a/src/main/java/ArraySortedBag.java
+++ b/src/main/java/ArraySortedBag.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * Implementation of a SortedBag with an array as the container. The array container will automatically "grow" to
  * accommodate adding beyond the initial capacity.
  *
- * @param <T> Type of elements that are to be in the SortedBag.
+ * @param <T> Type of elements that are to be in the SortedBag
  */
 public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBag<T> {
 
@@ -28,7 +28,7 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
     /**
      * Create an empty ArraySortedBag with the specified capacity.
      *
-     * @param initialCapacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array
      */
     @SuppressWarnings("unchecked")
     public ArraySortedBag(int initialCapacity) {
@@ -41,7 +41,7 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
      * Shifts elements in an array down (towards index 0) to the starting index specified. The element at the starting
      * index will be overwritten.
      *
-     * @param start Index of element to be overwritten and where shifting moves down to.
+     * @param start Index of element to be overwritten and where shifting moves down to
      */
     private void shiftLeft(int start) {
         for (int i = start; i < rear - 1; i++) {
@@ -55,7 +55,7 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
      * at the specified starting index will be open. This method assumes there is room in the array to facilitate the
      * shifting.
      *
-     * @param start Index of where the array has a new open location and where shifting moves up from.
+     * @param start Index of where the array has a new open location and where shifting moves up from
      */
     private void shiftRight(int start) {
         for (int i = rear; i > start; i--) {
@@ -68,8 +68,8 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
      * Find and return the index of a given target element within the collection. If no such element exists within the
      * collection, a sentinel value of -1 (NOT_FOUND constant) is returned.
      *
-     * @param element Element to find the index of.
-     * @return Index of the target element within the collection, or -1 (NOT_FOUND constant) if no such element exists.
+     * @param element Element to find the index of
+     * @return Index of the target element within the collection, or -1 (NOT_FOUND constant) if no such element exists
      */
     private int find(T element) {
         int searchIndex = 0;
@@ -101,8 +101,8 @@ public class ArraySortedBag<T extends Comparable<? super T>> implements SortedBa
      * Linear search through the bag to find the index of where the element should be inserted. If equal elements
      * exist within the collection, the returned index will be after the existing equal elements.
      *
-     * @param element Item to be inserted.
-     * @return Index where the element should be inserted.
+     * @param element Item to be inserted
+     * @return Index where the element should be inserted
      */
     private int findInsertIndex(T element) {
         int searchIndex = 0;

--- a/src/main/java/ArrayStack.java
+++ b/src/main/java/ArrayStack.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * Implementation of a stack with an array as the container. The array container will automatically "grow" to
  * accommodate adding beyond the initial capacity.
  *
- * @param <T> Type of elements that are to be in the stack.
+ * @param <T> Type of elements that are to be in the stack
  */
 public class ArrayStack<T> implements Stack<T> {
 
@@ -29,7 +29,7 @@ public class ArrayStack<T> implements Stack<T> {
     /**
      * Create an empty ArrayStack with the specified capacity.
      *
-     * @param initialCapacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array
      */
     @SuppressWarnings("unchecked")
     public ArrayStack(int initialCapacity) {

--- a/src/main/java/Bag.java
+++ b/src/main/java/Bag.java
@@ -3,46 +3,46 @@ import java.util.Iterator;
 /**
  * A bag is a linear data structure. Bags have no defined ordering. Elements can be added and removed from a bag.
  *
- * @param <T> Type of elements that are to be in the bag.
+ * @param <T> Type of elements that are to be in the bag
  */
 public interface Bag<T> extends Iterable<T> {
 
     /**
      * Add an element to the bag.
      *
-     * @param element Element to be added to the bag.
-     * @return True if the element was added successfully, false otherwise.
+     * @param element Element to be added to the bag
+     * @return True if the element was added successfully, false otherwise
      */
     boolean add(T element);
 
     /**
      * Removes a single instance of the specified element from the bag.
      *
-     * @param element Element to be removed from the bag.
-     * @return True if the element was removed successfully, false otherwise.
+     * @param element Element to be removed from the bag
+     * @return True if the element was removed successfully, false otherwise
      */
     boolean remove(T element);
 
     /**
      * Returns true if the bag contains the specified element.
      *
-     * @param element Element whose presence in the bag is to be tested.
-     * @return True if the element is contained within the bag, false otherwise.
+     * @param element Element whose presence in the bag is to be tested
+     * @return True if the element is contained within the bag, false otherwise
      */
     boolean contains(T element);
 
     /**
      * Returns the number of occurrences of an element contained within the bag.
      *
-     * @param element Element to be counted.
-     * @return Number of times the element can be found in the bag.
+     * @param element Element to be counted
+     * @return Number of times the element can be found in the bag
      */
     int count(T element);
 
     /**
      * Returns true if the bag contains no elements.
      *
-     * @return True if the bag is empty, false otherwise.
+     * @return True if the bag is empty, false otherwise
      */
     boolean isEmpty();
 
@@ -50,14 +50,14 @@ public interface Bag<T> extends Iterable<T> {
      * Returns the number of elements in the bag. This method does not handle the case of size exceeding
      * Integer.MAX_VALUE.
      *
-     * @return The number of elements in the bag.
+     * @return The number of elements in the bag
      */
     int size();
 
     /**
      * Returns an iterator over the elements in the bag.
      *
-     * @return An Iterator over the elements in the bag.
+     * @return An Iterator over the elements in the bag
      */
     Iterator<T> iterator();
 }

--- a/src/main/java/BinaryNode.java
+++ b/src/main/java/BinaryNode.java
@@ -2,7 +2,7 @@
  * A node class for a linked binary tree structure. Each node contains a nullable reference to data of type T, and a
  * reference to the left and right child nodes, which may be null references.
  *
- * @param <T> Type of the data being stored in the node.
+ * @param <T> Type of the data being stored in the node
  */
 public class BinaryNode<T> {
 

--- a/src/main/java/BinarySearchTree.java
+++ b/src/main/java/BinarySearchTree.java
@@ -7,7 +7,7 @@ import java.util.NoSuchElementException;
  * elements themselves determine the ordering. All modifications to the binary search tree contents are done in such a
  * way that binary search tree property is maintained.
  *
- * @param <T> Type of elements that are to be in the binary search tree.
+ * @param <T> Type of elements that are to be in the binary search tree
  */
 public interface BinarySearchTree<T extends Comparable<? super T>> extends BinaryTree<T> {
 
@@ -15,8 +15,8 @@ public interface BinarySearchTree<T extends Comparable<? super T>> extends Binar
      * Add an element to the binary search tree such that the binary search tree property is maintained. Equal
      * elements are added to the right.
      *
-     * @param element Element to be added to the binary search tree.
-     * @return True if the element was added successfully, false otherwise.
+     * @param element Element to be added to the binary search tree
+     * @return True if the element was added successfully, false otherwise
      */
     @Override
     boolean add(T element);
@@ -25,8 +25,8 @@ public interface BinarySearchTree<T extends Comparable<? super T>> extends Binar
      * Removes a single instance of the specified element from the binary search tree such that the binary search
      * tree property is maintained.
      *
-     * @param element Element to be removed from the binary search tree.
-     * @return True if the element was removed successfully, false otherwise.
+     * @param element Element to be removed from the binary search tree
+     * @return True if the element was removed successfully, false otherwise
      */
     @Override
     boolean remove(T element);
@@ -36,8 +36,8 @@ public interface BinarySearchTree<T extends Comparable<? super T>> extends Binar
      * Removes and returns the minimum element from the binary search tree such that the binary search tree property is
      * maintained.
      *
-     * @return The minimum element currently in the binary search tree.
-     * @throws NoSuchElementException If the binary search tree is empty.
+     * @return The minimum element currently in the binary search tree
+     * @throws NoSuchElementException If the binary search tree is empty
      */
     T removeMin();
 
@@ -45,24 +45,24 @@ public interface BinarySearchTree<T extends Comparable<? super T>> extends Binar
      * Removes and returns the maximum element from the binary search tree such that the binary search tree property is
      * maintained.
      *
-     * @return The maximum element currently in the binary search tree.
-     * @throws NoSuchElementException If the binary search tree is empty.
+     * @return The maximum element currently in the binary search tree
+     * @throws NoSuchElementException If the binary search tree is empty
      */
     T removeMax();
 
     /**
      * Returns the minimum element from the binary search tree.
      *
-     * @return The minimum element currently in the binary search tree.
-     * @throws NoSuchElementException If the binary search tree is empty.
+     * @return The minimum element currently in the binary search tree
+     * @throws NoSuchElementException If the binary search tree is empty
      */
     T min();
 
     /**
      * Returns the maximum element from the binary search tree.
      *
-     * @return The maximum element currently in the binary search tree.
-     * @throws NoSuchElementException If the binary search tree is empty.
+     * @return The maximum element currently in the binary search tree
+     * @throws NoSuchElementException If the binary search tree is empty
      */
     T max();
 }

--- a/src/main/java/BinaryTree.java
+++ b/src/main/java/BinaryTree.java
@@ -5,46 +5,46 @@ import java.util.Iterator;
  * referred to as the left and right children. The relative position of the nodes matter (left vs. right). Additionally,
  * each node has at most one parent node. Only the root node has no parent node.
  *
- * @param <T> Type of elements that are to be in the binary tree.
+ * @param <T> Type of elements that are to be in the binary tree
  */
 public interface BinaryTree<T> extends Iterable<T> {
 
     /**
      * Add an element to the binary tree.
      *
-     * @param element Element to be added to the binary tree.
-     * @return True if the element was added successfully, false otherwise.
+     * @param element Element to be added to the binary tree
+     * @return True if the element was added successfully, false otherwise
      */
     boolean add(T element);
 
     /**
      * Removes a single instance of the specified element from the binary tree.
      *
-     * @param element Element to be removed from the binary tree.
-     * @return True if the element was removed successfully, false otherwise.
+     * @param element Element to be removed from the binary tree
+     * @return True if the element was removed successfully, false otherwise
      */
     boolean remove(T element);
 
     /**
      * Returns true if the binary tree contains the specified element.
      *
-     * @param element Element whose presence in the binary tree is to be tested.
-     * @return True if the element is contained within the binary tree, false otherwise.
+     * @param element Element whose presence in the binary tree is to be tested
+     * @return True if the element is contained within the binary tree, false otherwise
      */
     boolean contains(T element);
 
     /**
      * Returns the number of occurrences of an element contained within the binary tree.
      *
-     * @param target Element to be counted.
-     * @return Number of times the element can be found in the bag.
+     * @param target Element to be counted
+     * @return Number of times the element can be found in the bag
      */
     int count(T target);
 
     /**
      * Returns true if the binary tree contains no elements.
      *
-     * @return True if the binary tree is empty, false otherwise.
+     * @return True if the binary tree is empty, false otherwise
      */
     boolean isEmpty();
 
@@ -52,42 +52,42 @@ public interface BinaryTree<T> extends Iterable<T> {
      * Returns the number of elements in the binary tree. This method does not handle the case of size exceeding
      * Integer.MAX_VALUE.
      *
-     * @return The number of elements in the binary tree.
+     * @return The number of elements in the binary tree
      */
     int size();
 
     /**
      * Returns an iterator over the elements in the binary tree.
      *
-     * @return An iterator over the elements in the binary tree.
+     * @return An iterator over the elements in the binary tree
      */
     Iterator<T> iterator();
 
     /**
      * Returns a pre-order iterator over the elements in the binary tree.
      *
-     * @return A pre-order iterator over the elements in the binary tree.
+     * @return A pre-order iterator over the elements in the binary tree
      */
     Iterator<T> preOrderIterator();
 
     /**
      * Returns an in-order iterator over the elements in the binary tree.
      *
-     * @return An in-order iterator over the elements in the binary tree.
+     * @return An in-order iterator over the elements in the binary tree
      */
     Iterator<T> inOrderIterator();
 
     /**
      * Returns a post-order iterator over the elements in the binary tree.
      *
-     * @return A post-order iterator over the elements in the binary tree.
+     * @return A post-order iterator over the elements in the binary tree
      */
     Iterator<T> postOrderIterator();
 
     /**
      * Returns a level-order iterator over the elements in the binary tree.
      *
-     * @return A level-order iterator over the elements in the binary tree.
+     * @return A level-order iterator over the elements in the binary tree
      */
     Iterator<T> levelOrderIterator();
 }

--- a/src/main/java/ContactList.java
+++ b/src/main/java/ContactList.java
@@ -27,7 +27,7 @@ public class ContactList {
     /**
      * Create an empty ContactList with the array container's capacity being set to the specified size.
      *
-     * @param initialCapacity Starting capacity of the fixed length array.
+     * @param initialCapacity Starting capacity of the fixed length array
      */
     public ContactList(int initialCapacity) {
         size = 0;
@@ -40,8 +40,8 @@ public class ContactList {
     /**
      * Add a new friend to the ContactList.
      *
-     * @param friend Friend object to add to the ContactList.
-     * @return True if the friend was added successfully, false otherwise.
+     * @param friend Friend object to add to the ContactList
+     * @return True if the friend was added successfully, false otherwise
      */
     public boolean add(Friend friend) {
         // If we have run out of space in our array we need to deal with it by making a new array
@@ -77,8 +77,8 @@ public class ContactList {
     /**
      * Check if a given Friend object exists within the collection.
      *
-     * @param friend Friend object to check if it exists within the collection.
-     * @return True if the Friend exists within the collection, false otherwise.
+     * @param friend Friend object to check if it exists within the collection
+     * @return True if the Friend exists within the collection, false otherwise
      */
     public boolean contains(Friend friend) {
         return find(friend) != NOT_FOUND;
@@ -88,8 +88,8 @@ public class ContactList {
      * Private helper method to find and return the index of a given Friend object within the collection. If no such
      * Friend exists within the collection, a sentinel value of -1 (NOT_FOUND constant) is returned.
      *
-     * @param friend Friend to find the index of.
-     * @return Index of the Friend within the collection, or -1 (NOT_FOUND constant) if no such Friend exists.
+     * @param friend Friend to find the index of
+     * @return Index of the Friend within the collection, or -1 (NOT_FOUND constant) if no such Friend exists
      */
     private int find(Friend friend) {
         // Linear search for the friend we are trying to find
@@ -109,9 +109,9 @@ public class ContactList {
      * Return the index of the specified Friend object within the collection. If no such Friend exists within the
      * collection, a NoSuchElementException is thrown.
      *
-     * @param friend Friend object to find the index of within the collection.
-     * @return Index of the Friend object.
-     * @throws NoSuchElementException If no equal Friend object exists within the collection, throw an exception.
+     * @param friend Friend object to find the index of within the collection
+     * @return Index of the Friend object
+     * @throws NoSuchElementException If no equal Friend object exists within the collection, throw an exception
      */
     public int indexOf(Friend friend) {
         if (!contains(friend)) {
@@ -127,9 +127,9 @@ public class ContactList {
      * Return the Friend object at the specified index. If the provided index is out of bounds an
      * IndexOutOfBoundsException is thrown.
      *
-     * @param index Index of the Friend object to be returned.
-     * @return Friend object at the specified index.
-     * @throws IndexOutOfBoundsException If an invalid index is provided (negative, or too large).
+     * @param index Index of the Friend object to be returned
+     * @return Friend object at the specified index
+     * @throws IndexOutOfBoundsException If an invalid index is provided (negative, or too large)
      */
     public Friend get(int index) {
         if (index < 0 || index >= size()) {
@@ -146,8 +146,8 @@ public class ContactList {
      * being replaced in the  collection with the Friend object at the end of the collection. This, remove does not
      * preserve the order of the Friend objects within the collection.
      *
-     * @param friend Friend object to remove from the collection.
-     * @return True if the object was successfully removed, false otherwise.
+     * @param friend Friend object to remove from the collection
+     * @return True if the object was successfully removed, false otherwise
      */
     public boolean remove(Friend friend) {
         if (!contains(friend)) {
@@ -194,7 +194,7 @@ public class ContactList {
      * string representations of each of the Friend objects within the ContactList. Each Friend object's string will
      * be on its own line. If the ContactList is empty, an empty string is returned.
      *
-     * @return String representation of the ContactList.
+     * @return String representation of the ContactList
      */
     public String toString() {
         StringBuilder builder = new StringBuilder();
@@ -212,8 +212,8 @@ public class ContactList {
      * Checks if two ContactList objects are equal. ContactList objects are considered equal if the contents of their
      * friends field, an array, are all equal.
      *
-     * @param o an "object" being compared to.
-     * @return True if the two objects are equal, false otherwise.
+     * @param o an "object" being compared to
+     * @return True if the two objects are equal, false otherwise
      */
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/Friend.java
+++ b/src/main/java/Friend.java
@@ -53,8 +53,8 @@ public final class Friend {
     /**
      * Checks if two Friend objects are equal. Friend objects are considered equal if all their attributes are equal.
      *
-     * @param o an "object" being compared to.
-     * @return True if the two objects are equal, false otherwise.
+     * @param o an "object" being compared to
+     * @return True if the two objects are equal, false otherwise
      */
     @Override
     public boolean equals(Object o) {
@@ -72,7 +72,8 @@ public final class Friend {
         }
         // Cast o as a friend
         Friend other = (Friend) o;
-        return Objects.equals(this.firstName, other.firstName) && Objects.equals(this.lastName, other.lastName) &&
+        return Objects.equals(this.firstName, other.firstName) &&
+                Objects.equals(this.lastName, other.lastName) &&
                 Objects.equals(this.email, other.email);
     }
     // [end-equals]

--- a/src/main/java/IndexedBag.java
+++ b/src/main/java/IndexedBag.java
@@ -5,15 +5,15 @@ import java.util.NoSuchElementException;
  * ordering based on element position within the indexed bag. Every time an element is added or removed, the indices of
  * the elements within the indexed bag may change.
  *
- * @param <T> Type of elements that are to be in the indexed bag.
+ * @param <T> Type of elements that are to be in the indexed bag
  */
 public interface IndexedBag<T> extends Bag<T> {
 
     /**
      * Appends the specified element to the end of the indexed bag.
      *
-     * @param element Element to be appended to the indexed bag.
-     * @return True if the element was added successfully, false otherwise.
+     * @param element Element to be appended to the indexed bag
+     * @return True if the element was added successfully, false otherwise
      */
     @Override
     boolean add(T element);
@@ -22,18 +22,18 @@ public interface IndexedBag<T> extends Bag<T> {
      * Inserts the specified element at the specified position in the indexed bag. Shifts the element currently at that
      * position (if any) and any subsequent elements to the right (adds one to their indices).
      *
-     * @param index   Index at which the specified element is to be inserted.
-     * @param element Element to be inserted to the indexed bag.
-     * @return True if the element was added successfully, false otherwise.
-     * @throws IndexOutOfBoundsException If the index is out of range (index < 0 || index > size()).
+     * @param index   Index at which the specified element is to be inserted
+     * @param element Element to be inserted to the indexed bag
+     * @return True if the element was added successfully, false otherwise
+     * @throws IndexOutOfBoundsException If the index is out of range (index < 0 || index > size())
      */
     boolean add(int index, T element);
 
     /**
      * Replaces the element at the specified position in the indexed bag with the specified element.
      *
-     * @param index   Index of the element to replace.
-     * @param element Element to be stored at the specified position.
+     * @param index   Index of the element to replace
+     * @param element Element to be stored at the specified position
      * @return Element previously at the specified position
      */
     T set(int index, T element);
@@ -41,9 +41,9 @@ public interface IndexedBag<T> extends Bag<T> {
     /**
      * Returns the element at the specified position in the indexed bag.
      *
-     * @param index Index of the element to return.
-     * @return The element at the specified position in the indexed bag.
-     * @throws IndexOutOfBoundsException If the index is out of range (index < 0 || index >= size()).
+     * @param index Index of the element to return
+     * @return The element at the specified position in the indexed bag
+     * @throws IndexOutOfBoundsException If the index is out of range (index < 0 || index >= size())
      */
     T get(int index);
 
@@ -51,9 +51,9 @@ public interface IndexedBag<T> extends Bag<T> {
      * Removes the element at the specified position in the indexed bag. Shifts any subsequent elements to the left
      * (subtracts one from their indices). Returns the element that was removed from the indexed bag.
      *
-     * @param index The index of the element to be removed.
-     * @return The element previously at the specified position.
-     * @throws IndexOutOfBoundsException If the index is out of range (index < 0 || index >= size()).
+     * @param index The index of the element to be removed
+     * @return The element previously at the specified position
+     * @throws IndexOutOfBoundsException If the index is out of range (index < 0 || index >= size())
      */
     T remove(int index);
 
@@ -61,8 +61,8 @@ public interface IndexedBag<T> extends Bag<T> {
      * Returns the index of the first occurrence of the specified element in the indexed bag.
      *
      * @param element Element to search for
-     * @return The index of the first occurrence of the specified element in the indexed bag.
-     * @throws NoSuchElementException If the provided element does not exist within the indexed bag.
+     * @return The index of the first occurrence of the specified element in the indexed bag
+     * @throws NoSuchElementException If the provided element does not exist within the indexed bag
      */
     int indexOf(T element);
 }

--- a/src/main/java/LinkedQueue.java
+++ b/src/main/java/LinkedQueue.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Implementation of a queue with a linked structure as the container. The class contains a static inner class defining
  * a node for the linked structure.
  *
- * @param <T> Type of elements that are to be in the queue.
+ * @param <T> Type of elements that are to be in the queue
  */
 public class LinkedQueue<T> implements Queue<T> {
 
@@ -130,7 +130,7 @@ public class LinkedQueue<T> implements Queue<T> {
      * A node class for a singly linked structure. Each node contains a nullable reference to data of type T, and a
      * reference to the next/subsequent/successor singly linked node, which may be a null reference.
      *
-     * @param <T> Type of the data being stored in the node.
+     * @param <T> Type of the data being stored in the node
      */
     private static class Node<T> {
 

--- a/src/main/java/LinkedStack.java
+++ b/src/main/java/LinkedStack.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Implementation of a stack with a linked structure as the container. The class contains a static inner class defining
  * a node for the linked structure.
  *
- * @param <T> Type of elements that are to be in the stack.
+ * @param <T> Type of elements that are to be in the stack
  */
 public class LinkedStack<T> implements Stack<T> {
 
@@ -124,7 +124,7 @@ public class LinkedStack<T> implements Stack<T> {
      * A node class for a singly linked structure. Each node contains a nullable reference to data of type T, and a
      * reference to the next/subsequent/successor singly linked node, which may be a null reference.
      *
-     * @param <T> Type of the data being stored in the node.
+     * @param <T> Type of the data being stored in the node
      */
     private static class Node<T> {
 

--- a/src/main/java/Node.java
+++ b/src/main/java/Node.java
@@ -2,7 +2,7 @@
  * A node class for a singly linked structure. Each node contains a nullable reference to data of type T, and a
  * reference to the next/subsequent/successor singly linked node, which may be a null reference.
  *
- * @param <T> Type of the data being stored in the node.
+ * @param <T> Type of the data being stored in the node
  */
 public class Node<T> {
 

--- a/src/main/java/Queue.java
+++ b/src/main/java/Queue.java
@@ -6,7 +6,7 @@ import java.util.NoSuchElementException;
  * structure has a "first in, first out" (FIFO) property --- the first element that was added to the queue would be the
  * first element that gets removed if a remove were to happen.
  *
- * @param <T> Type of elements that are to be in the queue.
+ * @param <T> Type of elements that are to be in the queue
  */
 public interface Queue<T> {
 
@@ -15,8 +15,8 @@ public interface Queue<T> {
      * Adds (enqueues) an element to the queue. The enqueue adds the element at the back of the queue such that it
      * becomes the new last thing in the queue.
      *
-     * @param element The item to be enqueued (added) to the queue.
-     * @return True if the element was enqueued (added) successfully, false otherwise.
+     * @param element The item to be enqueued (added) to the queue
+     * @return True if the element was enqueued (added) successfully, false otherwise
      */
     boolean enqueue(T element);
 
@@ -26,8 +26,8 @@ public interface Queue<T> {
      * from the front of the queue such that the subsequent element, if it exists, becomes the new front of the queue.
      * If no subsequent element exists, the front will be null and the queue will be empty.
      *
-     * @return The element at the front of the queue.
-     * @throws NoSuchElementException If removing from an empty queue.
+     * @return The element at the front of the queue
+     * @throws NoSuchElementException If removing from an empty queue
      */
     T dequeue();
 
@@ -35,8 +35,8 @@ public interface Queue<T> {
      * Return the element at the front of the queue. Calling first leaves the element at the front of the queue and
      * leaves the queue unchanged.
      *
-     * @return The element at the front of the queue.
-     * @throws NoSuchElementException If calling first on an empty queue.
+     * @return The element at the front of the queue
+     * @throws NoSuchElementException If calling first on an empty queue
      */
     T first();
 
@@ -44,7 +44,7 @@ public interface Queue<T> {
     /**
      * Checks if the queue is currently empty.
      *
-     * @return True if the queue is empty, false otherwise.
+     * @return True if the queue is empty, false otherwise
      */
     boolean isEmpty();
 
@@ -52,7 +52,7 @@ public interface Queue<T> {
      * Returns the number of elements in the queue. This method does not handle the case of size exceeding
      * Integer.MAX_VALUE.
      *
-     * @return The number of elements in the queue.
+     * @return The number of elements in the queue
      */
     int size();
 }

--- a/src/main/java/SortedBag.java
+++ b/src/main/java/SortedBag.java
@@ -5,15 +5,15 @@ import java.util.NoSuchElementException;
  * characteristics of the type of elements within the sorted bag; the elements themselves determine the ordering. All
  * modifications to the sorted bag's contents are done in such a way that the ordering is preserved.
  *
- * @param <T> Type of elements that are to be in the sorted bag. These elements must have a defined ordering.
+ * @param <T> Type of elements that are to be in the sorted bag. These elements must have a defined ordering
  */
 public interface SortedBag<T extends Comparable<? super T>> extends Bag<T> {
 
     /**
      * Adds the specified element to the sorted bag such that the sorted bag remains sorted.
      *
-     * @param element Element to be added to the sorted bag.
-     * @return True if the element was added successfully, false otherwise.
+     * @param element Element to be added to the sorted bag
+     * @return True if the element was added successfully, false otherwise
      */
     @Override
     boolean add(T element);
@@ -21,8 +21,8 @@ public interface SortedBag<T extends Comparable<? super T>> extends Bag<T> {
     /**
      * Removes a single instance of the specified element from the bag such that the sorted bag remains sorted.
      *
-     * @param element Element to be removed from the bag.
-     * @return True if the element was removed successfully, false otherwise.
+     * @param element Element to be removed from the bag
+     * @return True if the element was removed successfully, false otherwise
      */
     @Override
     boolean remove(T element);
@@ -31,8 +31,8 @@ public interface SortedBag<T extends Comparable<? super T>> extends Bag<T> {
      * Removes the first (lowest) element from the sorted bag. The remove is done in such a way that the order of the
      * elements within the sorted bag is preserved. Returns the element that was removed from the sorted bag.
      *
-     * @return The first (lowest) element currently in the sorted bag.
-     * @throws NoSuchElementException If the sorted bag is empty.
+     * @return The first (lowest) element currently in the sorted bag
+     * @throws NoSuchElementException If the sorted bag is empty
      */
     T removeFirst();
 
@@ -40,24 +40,24 @@ public interface SortedBag<T extends Comparable<? super T>> extends Bag<T> {
      * Removes the last (highest) element from the sorted bag. The remove is done in such a way that the order of the
      * elements within the sorted bag is preserved. Returns the element that was removed from the sorted bag.
      *
-     * @return The last (highest) element currently in the sorted bag.
-     * @throws NoSuchElementException If the sorted bag is empty.
+     * @return The last (highest) element currently in the sorted bag
+     * @throws NoSuchElementException If the sorted bag is empty
      */
     T removeLast();
 
     /**
      * Returns the first (lowest) element currently in the sorted bag.
      *
-     * @return The first (lowest) element currently in the sorted bag.
-     * @throws NoSuchElementException If the sorted bag is empty.
+     * @return The first (lowest) element currently in the sorted bag
+     * @throws NoSuchElementException If the sorted bag is empty
      */
     T first();
 
     /**
      * Returns the last (highest) element currently in the sorted bag.
      *
-     * @return The last (highest) element currently in the sorted bag.
-     * @throws NoSuchElementException If the sorted bag is empty.
+     * @return The last (highest) element currently in the sorted bag
+     * @throws NoSuchElementException If the sorted bag is empty
      */
     T last();
 }

--- a/src/main/java/Stack.java
+++ b/src/main/java/Stack.java
@@ -6,7 +6,7 @@ import java.util.NoSuchElementException;
  * is disallowed. This data structure has a "last in, first out" (LIFO) property --- the last element that was added to
  * the stack would be the first element removed from the stack if a remove were to happen.
  *
- * @param <T> Type of elements that are to be in the stack.
+ * @param <T> Type of elements that are to be in the stack
  */
 public interface Stack<T> {
 
@@ -14,8 +14,8 @@ public interface Stack<T> {
      * Adds (pushes) an element to the stack. The push adds the element to the stack such that it becomes the new top of
      * the stack.
      *
-     * @param element The item to be pushed (added) to the stack.
-     * @return True if the element was pushed (added) successfully, false otherwise.
+     * @param element The item to be pushed (added) to the stack
+     * @return True if the element was pushed (added) successfully, false otherwise
      */
     boolean push(T element);
 
@@ -24,8 +24,8 @@ public interface Stack<T> {
      * top of the stack such that the subsequent element, if it exists, becomes the new top of the stack. If no
      * subsequent element exists, the top will be null and the stack will be empty.
      *
-     * @return The element at the top of the stack.
-     * @throws NoSuchElementException If removing from an empty stack.
+     * @return The element at the top of the stack
+     * @throws NoSuchElementException If removing from an empty stack
      */
     T pop();
 
@@ -33,15 +33,15 @@ public interface Stack<T> {
      * Return the element at the top of the stack. Calling peek leaves the element at the top of the stack and leaves
      * the stack unchanged.
      *
-     * @return The element at the top of the stack.
-     * @throws NoSuchElementException If calling peek on an empty stack.
+     * @return The element at the top of the stack
+     * @throws NoSuchElementException If calling peek on an empty stack
      */
     T peek();
 
     /**
      * Checks if the stack is currently empty.
      *
-     * @return True if the stack is empty, false otherwise.
+     * @return True if the stack is empty, false otherwise
      */
     boolean isEmpty();
 
@@ -49,7 +49,7 @@ public interface Stack<T> {
      * Returns the number of elements in the stack. This method does not handle the case of size exceeding
      * Integer.MAX_VALUE.
      *
-     * @return The number of elements in the stack.
+     * @return The number of elements in the stack
      */
     int size();
 }


### PR DESCRIPTION
### Related Issues or PRs
Closes #810 

### What
Remove the periods in the param/return/throws lines in the javadoc comments

### Why
conforms to what I was seeing in the standard library

### Testing
YOLO

### Additional Notes
It does feel weird using other punctuation, like commas, and not periods, but whatever. 
