### PR TITLE
:lipstick: :technologist: Equals tests --- Make use of `of` method

### DIFF
--- a/src/test/java/ArrayQueueEqualsTest.java
+++ b/src/test/java/ArrayQueueEqualsTest.java
@@ -6,35 +6,23 @@ class ArrayQueueEqualsTest {
     @Test
     @SuppressWarnings("UnstableApiUsage")
     public void equals_verify_contract() {
-        ArrayQueue<Integer> emptyA = new ArrayQueue<>();
-        ArrayQueue<Integer> emptyB = new ArrayQueue<>();
-        ArrayQueue<Integer> emptyC = new ArrayQueue<>(1000);
+        ArrayQueue<Integer> emptyA = of();
+        ArrayQueue<Integer> emptyB = of();
+        ArrayQueue<Integer> emptyC = ofCapacity();
 
-        ArrayQueue<Integer> singletonA = new ArrayQueue<>();
-        ArrayQueue<Integer> singletonB = new ArrayQueue<>();
-        ArrayQueue<Integer> singletonC = new ArrayQueue<>(1000);
-        ArrayQueue<Integer> singletonD = new ArrayQueue<>();        // Different start
-        singletonA.enqueue(10);
-        singletonB.enqueue(10);
-        singletonC.enqueue(10);
+        ArrayQueue<Integer> singletonA = of(10);
+        ArrayQueue<Integer> singletonB = of(10);
+        ArrayQueue<Integer> singletonC = ofCapacity(10);
+        ArrayQueue<Integer> singletonD = new ArrayQueue<>();            // Different start
         singletonD.enqueue(0);
         singletonD.dequeue();
         singletonD.enqueue(10);
 
-        ArrayQueue<Integer> manyA = new ArrayQueue<>();
-        ArrayQueue<Integer> manyB = new ArrayQueue<>();
-        ArrayQueue<Integer> manyC = new ArrayQueue<>(1000);
-        ArrayQueue<Integer> manyD = new ArrayQueue<>();             // Different start
+        ArrayQueue<Integer> manyA = of(10, 20, 30);
+        ArrayQueue<Integer> manyB = of(10, 20, 30);
+        ArrayQueue<Integer> manyC = ofCapacity(10, 20, 30);
+        ArrayQueue<Integer> manyD = new ArrayQueue<>();                 // Different start
         ArrayQueue<Integer> manyW = new ArrayQueue<>(5);    // Wraps rear
-        manyA.enqueue(10);
-        manyA.enqueue(20);
-        manyA.enqueue(30);
-        manyB.enqueue(10);
-        manyB.enqueue(20);
-        manyB.enqueue(30);
-        manyC.enqueue(10);
-        manyC.enqueue(20);
-        manyC.enqueue(30);
         manyD.enqueue(0);
         manyD.dequeue();
         manyD.enqueue(10);
@@ -50,24 +38,10 @@ class ArrayQueueEqualsTest {
         manyW.enqueue(20);
         manyW.enqueue(30);
 
-        ArrayQueue<Integer> unequalDifferentValues = new ArrayQueue<>();
-        unequalDifferentValues.enqueue(110);
-        unequalDifferentValues.enqueue(120);
-        unequalDifferentValues.enqueue(130);
-
-        ArrayQueue<Integer> unequalDifferentOrder = new ArrayQueue<>();
-        unequalDifferentOrder.enqueue(30);
-        unequalDifferentOrder.enqueue(20);
-        unequalDifferentOrder.enqueue(10);
-
-        ArrayQueue<Integer> unequalDifferentSizes = new ArrayQueue<>();
-        unequalDifferentSizes.enqueue(10);
-        unequalDifferentSizes.enqueue(20);
-
-        ArrayQueue<Integer> unequalSomeEqual = new ArrayQueue<>();
-        unequalSomeEqual.enqueue(20);
-        unequalSomeEqual.enqueue(30);
-        unequalSomeEqual.enqueue(40);
+        ArrayQueue<Integer> unequalDifferentValues = of(110, 120, 130);
+        ArrayQueue<Integer> unequalDifferentOrder = of(30, 20, 10);
+        ArrayQueue<Integer> unequalDifferentSizes = of(10, 20);
+        ArrayQueue<Integer> unequalSomeEqual = of(20, 30, 40);
 
         new EqualsTester().addEqualityGroup(ArrayQueue.class)
                 .addEqualityGroup(emptyA, emptyB, emptyC)
@@ -78,5 +52,21 @@ class ArrayQueueEqualsTest {
                 .addEqualityGroup(unequalDifferentSizes)
                 .addEqualityGroup(unequalSomeEqual)
                 .testEquals();
+    }
+
+    private <T> ArrayQueue<T> of(T... ts) {
+        ArrayQueue<T> queue = new ArrayQueue<>();
+        for (T element : ts) {
+            queue.enqueue(element);
+        }
+        return queue;
+    }
+
+    private <T> ArrayQueue<T> ofCapacity(T... ts) {
+        ArrayQueue<T> queue = new ArrayQueue<>(1000);
+        for (T element : ts) {
+            queue.enqueue(element);
+        }
+        return queue;
     }
 }

--- a/src/test/java/ArrayStackEqualsTest.java
+++ b/src/test/java/ArrayStackEqualsTest.java
@@ -19,13 +19,9 @@ class ArrayStackEqualsTest {
         ArrayStack<Integer> manyB = of(10, 20, 30);
         ArrayStack<Integer> manyC = ofCapacity(10, 20, 30);
 
-
         ArrayStack<Integer> unequalDifferentValues = of(110, 120, 130);
-
         ArrayStack<Integer> unequalDifferentOrder = of(30, 20, 10);
-
         ArrayStack<Integer> unequalDifferentSizes = of(10, 20);
-
         ArrayStack<Integer> unequalSomeEqual = of(20, 30, 40);
 
         new EqualsTester().addEqualityGroup(ArrayStack.class)

--- a/src/test/java/ArrayStackEqualsTest.java
+++ b/src/test/java/ArrayStackEqualsTest.java
@@ -1,6 +1,5 @@
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;
-import playground.ArrayStack;
 
 class ArrayStackEqualsTest {
 

--- a/src/test/java/ArrayStackEqualsTest.java
+++ b/src/test/java/ArrayStackEqualsTest.java
@@ -1,53 +1,32 @@
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;
+import playground.ArrayStack;
 
 class ArrayStackEqualsTest {
 
     @Test
     @SuppressWarnings("UnstableApiUsage")
     public void equals_verify_contract() {
-        ArrayStack<Integer> emptyA = new ArrayStack<>();
-        ArrayStack<Integer> emptyB = new ArrayStack<>();
-        ArrayStack<Integer> emptyC = new ArrayStack<>(1000);
+        ArrayStack<Integer> emptyA = of();
+        ArrayStack<Integer> emptyB = of();
+        ArrayStack<Integer> emptyC = ofCapacity();
 
-        ArrayStack<Integer> singletonA = new ArrayStack<>();
-        ArrayStack<Integer> singletonB = new ArrayStack<>();
-        ArrayStack<Integer> singletonC = new ArrayStack<>(1000);
-        singletonA.push(10);
-        singletonB.push(10);
-        singletonC.push(10);
+        ArrayStack<Integer> singletonA = of(10);
+        ArrayStack<Integer> singletonB = of(10);
+        ArrayStack<Integer> singletonC = ofCapacity(10);
 
-        ArrayStack<Integer> manyA = new ArrayStack<>();
-        ArrayStack<Integer> manyB = new ArrayStack<>();
-        ArrayStack<Integer> manyC = new ArrayStack<>(1000);
-        manyA.push(10);
-        manyA.push(20);
-        manyA.push(30);
-        manyB.push(10);
-        manyB.push(20);
-        manyB.push(30);
-        manyC.push(10);
-        manyC.push(20);
-        manyC.push(30);
+        ArrayStack<Integer> manyA = of(10, 20, 30);
+        ArrayStack<Integer> manyB = of(10, 20, 30);
+        ArrayStack<Integer> manyC = ofCapacity(10, 20, 30);
 
-        ArrayStack<Integer> unequalDifferentValues = new ArrayStack<>();
-        unequalDifferentValues.push(110);
-        unequalDifferentValues.push(120);
-        unequalDifferentValues.push(130);
 
-        ArrayStack<Integer> unequalDifferentOrder = new ArrayStack<>();
-        unequalDifferentOrder.push(30);
-        unequalDifferentOrder.push(20);
-        unequalDifferentOrder.push(10);
+        ArrayStack<Integer> unequalDifferentValues = of(110, 120, 130);
 
-        ArrayStack<Integer> unequalDifferentSizes = new ArrayStack<>();
-        unequalDifferentSizes.push(10);
-        unequalDifferentSizes.push(20);
+        ArrayStack<Integer> unequalDifferentOrder = of(30, 20, 10);
 
-        ArrayStack<Integer> unequalSomeEqual = new ArrayStack<>();
-        unequalSomeEqual.push(20);
-        unequalSomeEqual.push(30);
-        unequalSomeEqual.push(40);
+        ArrayStack<Integer> unequalDifferentSizes = of(10, 20);
+
+        ArrayStack<Integer> unequalSomeEqual = of(20, 30, 40);
 
         new EqualsTester().addEqualityGroup(ArrayStack.class)
                 .addEqualityGroup(emptyA, emptyB, emptyC)
@@ -58,5 +37,21 @@ class ArrayStackEqualsTest {
                 .addEqualityGroup(unequalDifferentSizes)
                 .addEqualityGroup(unequalSomeEqual)
                 .testEquals();
+    }
+
+    private <T> ArrayStack<T> of(T... ts) {
+        ArrayStack<T> stack = new ArrayStack<>();
+        for (T element : ts) {
+            stack.push(element);
+        }
+        return stack;
+    }
+
+    private <T> ArrayStack<T> ofCapacity(T... ts) {
+        ArrayStack<T> stack = new ArrayStack<>(1000);
+        for (T element : ts) {
+            stack.push(element);
+        }
+        return stack;
     }
 }

--- a/src/test/java/ContactListEqualsTest.java
+++ b/src/test/java/ContactListEqualsTest.java
@@ -22,22 +22,18 @@ public class ContactListEqualsTest {
         ContactList manyC = ofCapacity(new Friend("Bob", "Smith", "bsmith@gmail.com"),
                 new Friend("Jane", "Doe", "jdoe@gmail.com"),
                 new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
-
-
+        
         ContactList unequalDifferentFriends = of(
                 new Friend("Sandy", "Seaside", "boatsboatsboats@yachtclub500.com"),
                 new Friend("Adam", "Fluffson", "fluffyman28@hotmail.com"),
                 new Friend("Adrian", "Andrews", "aandrews@hotmail.com"));
-
         ContactList unequalDifferentOrder = of(
                 new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"),
                 new Friend("Jane", "Doe", "jdoe@gmail.com"),
                 new Friend("Bob", "Smith", "bsmith@gmail.com"));
-
         ContactList unequalDifferentSize = of(
                 new Friend("Bob", "Smith", "bsmith@gmail.com"),
                 new Friend("Jane", "Doe", "jdoe@gmail.com"));
-
         ContactList unequalSomeEqualFriends = of(
                 new Friend("Bob", "Smith", "bsmith@gmail.com"),
                 new Friend("Jane", "Doe", "jdoe@gmail.com"),

--- a/src/test/java/ContactListEqualsTest.java
+++ b/src/test/java/ContactListEqualsTest.java
@@ -5,51 +5,46 @@ public class ContactListEqualsTest {
     @Test
     @SuppressWarnings("UnstableApiUsage")
     public void equals_verify_contract() {
-        ContactList emptyA = new ContactList();
-        ContactList emptyB = new ContactList();
-        ContactList emptyC = new ContactList(100);
+        ContactList emptyA = of();
+        ContactList emptyB = of();
+        ContactList emptyC = ofCapacity();
 
-        ContactList singletonA = new ContactList();
-        ContactList singletonB = new ContactList();
-        ContactList singletonC = new ContactList(100);
-        singletonA.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        singletonB.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        singletonC.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
+        ContactList singletonA = of(new Friend("Bob", "Smith", "bsmith@gmail.com"));
+        ContactList singletonB = of(new Friend("Bob", "Smith", "bsmith@gmail.com"));
+        ContactList singletonC = ofCapacity(new Friend("Bob", "Smith", "bsmith@gmail.com"));
 
-        ContactList manyA = new ContactList();
-        ContactList manyB = new ContactList();
-        ContactList manyC = new ContactList(100);
-        manyA.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        manyA.add(new Friend("Jane", "Doe", "jdoe@gmail.com"));
-        manyA.add(new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
-        manyB.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        manyB.add(new Friend("Jane", "Doe", "jdoe@gmail.com"));
-        manyB.add(new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
-        manyC.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        manyC.add(new Friend("Jane", "Doe", "jdoe@gmail.com"));
-        manyC.add(new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
+        ContactList manyA = of(new Friend("Bob", "Smith", "bsmith@gmail.com"),
+                new Friend("Jane", "Doe", "jdoe@gmail.com"),
+                new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
+        ContactList manyB = of(new Friend("Bob", "Smith", "bsmith@gmail.com"),
+                new Friend("Jane", "Doe", "jdoe@gmail.com"),
+                new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
+        ContactList manyC = ofCapacity(new Friend("Bob", "Smith", "bsmith@gmail.com"),
+                new Friend("Jane", "Doe", "jdoe@gmail.com"),
+                new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
 
-        ContactList unequalDifferentFriends = new ContactList();
-        unequalDifferentFriends.add(new Friend("Sandy", "Seaside", "boatsboatsboats@yachtclub500.com"));
-        unequalDifferentFriends.add(new Friend("Adam", "Fluffson", "fluffyman28@hotmail.com"));
-        unequalDifferentFriends.add(new Friend("Adrian", "Andrews", "aandrews@hotmail.com"));
 
-        ContactList unequalDifferentOrder = new ContactList();
-        unequalDifferentOrder.add(new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
-        unequalDifferentOrder.add(new Friend("Jane", "Doe", "jdoe@gmail.com"));
-        unequalDifferentOrder.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
+        ContactList unequalDifferentFriends = of(
+                new Friend("Sandy", "Seaside", "boatsboatsboats@yachtclub500.com"),
+                new Friend("Adam", "Fluffson", "fluffyman28@hotmail.com"),
+                new Friend("Adrian", "Andrews", "aandrews@hotmail.com"));
 
-        ContactList unequalDifferentSize = new ContactList();
-        unequalDifferentSize.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        unequalDifferentSize.add(new Friend("Jane", "Doe", "jdoe@gmail.com"));
+        ContactList unequalDifferentOrder = of(
+                new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"),
+                new Friend("Jane", "Doe", "jdoe@gmail.com"),
+                new Friend("Bob", "Smith", "bsmith@gmail.com"));
 
-        ContactList unequalSomeEqualFriends = new ContactList();
-        unequalSomeEqualFriends.add(new Friend("Bob", "Smith", "bsmith@gmail.com"));
-        unequalSomeEqualFriends.add(new Friend("Jane", "Doe", "jdoe@gmail.com"));
-        unequalSomeEqualFriends.add(new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"));
-        unequalSomeEqualFriends.add(new Friend("Sandy", "Seaside", "boatsboatsboats@yachtclub500.com"));
-        unequalSomeEqualFriends.add(new Friend("Adam", "Fluffson", "fluffyman28@hotmail.com"));
-        unequalSomeEqualFriends.add(new Friend("Adrian", "Andrews", "aandrews@hotmail.com"));
+        ContactList unequalDifferentSize = of(
+                new Friend("Bob", "Smith", "bsmith@gmail.com"),
+                new Friend("Jane", "Doe", "jdoe@gmail.com"));
+
+        ContactList unequalSomeEqualFriends = of(
+                new Friend("Bob", "Smith", "bsmith@gmail.com"),
+                new Friend("Jane", "Doe", "jdoe@gmail.com"),
+                new Friend("Clarence", "Cartwrite", "treelover1523@hotmail.com"),
+                new Friend("Sandy", "Seaside", "boatsboatsboats@yachtclub500.com"),
+                new Friend("Adam", "Fluffson", "fluffyman28@hotmail.com"),
+                new Friend("Adrian", "Andrews", "aandrews@hotmail.com"));
 
         new EqualsTester().addEqualityGroup(ContactList.class)
                 .addEqualityGroup(emptyA, emptyB, emptyC)
@@ -60,5 +55,21 @@ public class ContactListEqualsTest {
                 .addEqualityGroup(unequalDifferentSize)
                 .addEqualityGroup(unequalSomeEqualFriends)
                 .testEquals();
+    }
+
+    private ContactList of(Friend... friends) {
+        ContactList contactList = new ContactList();
+        for (Friend friend : friends) {
+            contactList.add(friend);
+        }
+        return contactList;
+    }
+
+    private ContactList ofCapacity(Friend... friends) {
+        ContactList contactList = new ContactList(100);
+        for (Friend friend : friends) {
+            contactList.add(friend);
+        }
+        return contactList;
     }
 }

--- a/src/test/java/LinkedQueueEqualsTest.java
+++ b/src/test/java/LinkedQueueEqualsTest.java
@@ -6,42 +6,19 @@ class LinkedQueueEqualsTest {
     @Test
     @SuppressWarnings("UnstableApiUsage")
     public void equals_verify_contract() {
-        LinkedQueue<Integer> emptyA = new LinkedQueue<>();
-        LinkedQueue<Integer> emptyB = new LinkedQueue<>();
+        LinkedQueue<Integer> emptyA = of();
+        LinkedQueue<Integer> emptyB = of();
 
-        LinkedQueue<Integer> singletonA = new LinkedQueue<>();
-        LinkedQueue<Integer> singletonB = new LinkedQueue<>();
-        singletonA.enqueue(10);
-        singletonB.enqueue(10);
+        LinkedQueue<Integer> singletonA = of(10);
+        LinkedQueue<Integer> singletonB = of(10);
 
+        LinkedQueue<Integer> manyA = of(10, 20, 30);
+        LinkedQueue<Integer> manyB = of(10, 20, 30);
 
-        LinkedQueue<Integer> manyA = new LinkedQueue<>();
-        LinkedQueue<Integer> manyB = new LinkedQueue<>();
-        manyA.enqueue(10);
-        manyA.enqueue(20);
-        manyA.enqueue(30);
-        manyB.enqueue(10);
-        manyB.enqueue(20);
-        manyB.enqueue(30);
-
-        LinkedQueue<Integer> unequalDifferentValues = new LinkedQueue<>();
-        unequalDifferentValues.enqueue(110);
-        unequalDifferentValues.enqueue(120);
-        unequalDifferentValues.enqueue(130);
-
-        LinkedQueue<Integer> unequalDifferentOrder = new LinkedQueue<>();
-        unequalDifferentOrder.enqueue(30);
-        unequalDifferentOrder.enqueue(20);
-        unequalDifferentOrder.enqueue(10);
-
-        LinkedQueue<Integer> unequalDifferentSizes = new LinkedQueue<>();
-        unequalDifferentSizes.enqueue(10);
-        unequalDifferentSizes.enqueue(20);
-
-        LinkedQueue<Integer> unequalSomeEqual = new LinkedQueue<>();
-        unequalSomeEqual.enqueue(20);
-        unequalSomeEqual.enqueue(30);
-        unequalSomeEqual.enqueue(40);
+        LinkedQueue<Integer> unequalDifferentValues = of(110, 120, 130);
+        LinkedQueue<Integer> unequalDifferentOrder = of(30, 20, 10);
+        LinkedQueue<Integer> unequalDifferentSizes = of(10, 20);
+        LinkedQueue<Integer> unequalSomeEqual = of(20, 30, 40);
 
         new EqualsTester().addEqualityGroup(LinkedQueue.class)
                 .addEqualityGroup(emptyA, emptyB)
@@ -52,5 +29,13 @@ class LinkedQueueEqualsTest {
                 .addEqualityGroup(unequalDifferentSizes)
                 .addEqualityGroup(unequalSomeEqual)
                 .testEquals();
+    }
+
+    private <T> LinkedQueue<T> of(T... ts) {
+        LinkedQueue<T> queue = new LinkedQueue<>();
+        for (T element : ts) {
+            queue.enqueue(element);
+        }
+        return queue;
     }
 }

--- a/src/test/java/LinkedStackEqualsTest.java
+++ b/src/test/java/LinkedStackEqualsTest.java
@@ -1,49 +1,27 @@
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;
+import playground.LinkedStack;
 
 class LinkedStackEqualsTest {
 
     @Test
     @SuppressWarnings("UnstableApiUsage")
     public void equals_verify_contract() {
-        LinkedStack<Integer> emptyA = new LinkedStack<>();
-        LinkedStack<Integer> emptyB = new LinkedStack<>();
+        LinkedStack<Integer> emptyA = of();
+        LinkedStack<Integer> emptyB = of();
 
-        LinkedStack<Integer> singletonA = new LinkedStack<>();
-        LinkedStack<Integer> singletonB = new LinkedStack<>();
-        singletonA.push(10);
-        singletonB.push(10);
+        LinkedStack<Integer> singletonA = of(10);
+        LinkedStack<Integer> singletonB = of(10);
 
+        LinkedStack<Integer> manyA = of(10, 20, 30);
+        LinkedStack<Integer> manyB = of(10, 20, 30);
 
-        LinkedStack<Integer> manyA = new LinkedStack<>();
-        LinkedStack<Integer> manyB = new LinkedStack<>();
-        manyA.push(10);
-        manyA.push(20);
-        manyA.push(30);
-        manyB.push(10);
-        manyB.push(20);
-        manyB.push(30);
+        LinkedStack<Integer> unequalDifferentValues = of(110, 120, 130);
+        LinkedStack<Integer> unequalDifferentOrder = of(30, 20, 10);
+        LinkedStack<Integer> unequalDifferentSizes = of(10, 20);
+        LinkedStack<Integer> unequalSomeEqual = of(20, 30, 40);
 
-        LinkedStack<Integer> unequalDifferentValues = new LinkedStack<>();
-        unequalDifferentValues.push(110);
-        unequalDifferentValues.push(120);
-        unequalDifferentValues.push(130);
-
-        LinkedStack<Integer> unequalDifferentOrder = new LinkedStack<>();
-        unequalDifferentOrder.push(30);
-        unequalDifferentOrder.push(20);
-        unequalDifferentOrder.push(10);
-
-        LinkedStack<Integer> unequalDifferentSizes = new LinkedStack<>();
-        unequalDifferentSizes.push(10);
-        unequalDifferentSizes.push(20);
-
-        LinkedStack<Integer> unequalSomeEqual = new LinkedStack<>();
-        unequalSomeEqual.push(20);
-        unequalSomeEqual.push(30);
-        unequalSomeEqual.push(40);
-
-        new EqualsTester().addEqualityGroup(ArrayStack.class)
+        new EqualsTester().addEqualityGroup(LinkedStack.class)
                 .addEqualityGroup(emptyA, emptyB)
                 .addEqualityGroup(singletonA, singletonB)
                 .addEqualityGroup(manyA, manyB)
@@ -52,5 +30,13 @@ class LinkedStackEqualsTest {
                 .addEqualityGroup(unequalDifferentSizes)
                 .addEqualityGroup(unequalSomeEqual)
                 .testEquals();
+    }
+
+    private <T> LinkedStack<T> of(T... ts) {
+        LinkedStack<T> stack = new LinkedStack<>();
+        for (T element : ts) {
+            stack.push(element);
+        }
+        return stack;
     }
 }

--- a/src/test/java/LinkedStackEqualsTest.java
+++ b/src/test/java/LinkedStackEqualsTest.java
@@ -1,6 +1,5 @@
 import com.google.common.testing.EqualsTester;
 import org.junit.jupiter.api.Test;
-import playground.LinkedStack;
 
 class LinkedStackEqualsTest {
 


### PR DESCRIPTION
### Related Issues or PRs
Closes #830 

### What
1. Create `of` factory methods to create the instances of the classes to check equality on 
2. Use the factory methods when creating the instances

### Why
Much cleaner 

### Testing
:+1: 

### Additional Notes
The `ArrayQueueEqualsTest` still does create a few instances without an `of` since they were peculiar and it didn't really make sense to make a method for these special cases. Specifically, the tests where the front of the queue is not at index `0` and when the queue's data loops back on the array.  
