### PR TITLE
:bug: :mortar_board: Topic array queue --- Correct 4/2 :microscope: 

### DIFF
--- a/src/site/topics/queues/array-queue.rst
+++ b/src/site/topics/queues/array-queue.rst
@@ -233,7 +233,7 @@ Modulo --- ``%``
 
     * ``4 % 2``
 
-        * ``4/2 == 0`` remainder ``0``
+        * ``4/2 == 2`` remainder ``0``
         * Therefore, ``4 % 2`` is ``0``
 
 


### PR DESCRIPTION
### What
`4/2 == 0` -> `4/2 == 2`

### Why
Because 4 divided by 2 is 2, not 0

### Testing
:-1: 