### PR TITLE
:lipstick: :mortar_board: Topic inheritance --- Clean formatting :microscope: 

### DIFF
--- a/src/site/topics/inheritance/inheritance.rst
+++ b/src/site/topics/inheritance/inheritance.rst
@@ -18,7 +18,7 @@ Inheritance
     :width: 500 px
     :align: center
 
-    Example class hierarchy for the ``Bag`` class and its subtypes --- ```SortedBag`` and ``IndexedBag``.
+    Example class hierarchy for the ``Bag`` class and its subtypes --- ``SortedBag`` and ``IndexedBag``.
 
 
 * This hierarchical thinking exists in everyday life
@@ -105,15 +105,12 @@ Abstract Class
 
 * The ``AbstractQueue`` has several important concrete methods implemented within the abstract class
 
-    * It also inherits a bunch from superclasses too
-
-
-* ``add``
-
+    * ``add``
     * ``addAll``
     * ``clear``
     * ``element``
     * ``remove``
+    * It also inherits a bunch from superclasses too
 
 
 * The ``PriorityQueue`` class, which ``extends AbstractQueue``, makes direct use of a few of these methods


### PR DESCRIPTION
### What
1. Remove extra backtick 
2. Reorder points 

### Why
1. It didn't render correctly because of this
2. Makes more sense (seems like it was done wrong originally)
