### PR TITLE
:bug: :mortar_board: Topic bag implementations --- Fix name of file for download :microscope: 

### DIFF
--- a/src/site/topics/bags/bag-implementations.rst
+++ b/src/site/topics/bags/bag-implementations.rst
@@ -177,7 +177,7 @@ ArraySortedBag
 .. note::
 
     For brevity, only a subset of methods are included below. See the
-    :download:`ArrayIndexedBag </../main/java/ArraySortedBag.java>` class for the full implementation.
+    :download:`ArraySortedBag </../main/java/ArraySortedBag.java>` class for the full implementation.
 
 
 .. literalinclude:: /../main/java/ArraySortedBag.java


### PR DESCRIPTION
### What
ArrayIndexedBag -> ArraySortedBag

### Why
It's the ArraySortedBag file to download, not an ArrayIndexedBag 
