### PR TITLE
:lipstick: :technologist: LinkedBinarySearchTree --- Simplify `max` :microscope: 

### DIFF
--- a/src/main/java/LinkedBinarySearchTree.java
+++ b/src/main/java/LinkedBinarySearchTree.java
@@ -228,16 +228,12 @@ public class LinkedBinarySearchTree<T extends Comparable<? super T>> implements 
         if (isEmpty()) {
             throw new NoSuchElementException("Empty Tree");
         }
-        if (root.getRight() == null) {
-            return root.getData();
-        } else {
-            Node<T> current = root.getRight();
-            // Iterate right until right most node is found
-            while (current.getRight() != null) {
-                current = current.getRight();
-            }
-            return current.getData();
+        Node<T> current = root;
+        // Iterate right until right most node is found
+        while (current.getRight() != null) {
+            current = current.getRight();
         }
+        return current.getData();
     }
     // [end-min_max]
 


### PR DESCRIPTION
### What
Simplify the `max` method to start at the root and not do an extra check on the root before the general check

### Why
The root case is the general case for the iterative implementation 

### How
Removed the check on the root.

### Testing
:+1: 

### Additional Notes
Not sure why it was implemented the way it originally was. I was trying to think if the way it was made it clearer, but I do not believe it does. There is a good chance this was a copy/paste form the `removeMax` or something that had this special case or something. 
