### PR TITLE
🧹 🎓 Topic bag implementations --- Remove note on `indexOf` throwing exception 🔬 

### DIFF
--- a/src/site/topics/bags/bag-implementations.rst
+++ b/src/site/topics/bags/bag-implementations.rst
@@ -158,7 +158,7 @@ Remove
 
 
 * The ``remove(T element)`` method delegates to the ``remove(int index)`` for ease and code/logic reuse
-* Note that ``indexOf`` will throw an exception if the element does not exist within the bag 
+
 
 
 ArraySortedBag


### PR DESCRIPTION
### What
Remove the comment about `indexOf` throwing an exception when discussing `remove(T element)` 

### Why
Not needed anymore. Although it's true, it's not worth bringing up since it should never be the case that `indexOf` throws the exception in the context of using `remove(T element). 

I assume this statement about it throwing an exception was included because of an [older version](https://github.com/jameshughes89/cs102/commit/b2718a3ecb498a75d88dee526cd44e65c7e6c750#diff-2629de0145c16321d5ee06868f864cf7b3a05b6c3db24aa95430b9b02041fb67R149) of the class that returned an element of type `T`, where this was changed to return a boolean. 

### Testing
Nah
