### PR TITLE
🐛 👯  🎓 Topic Exceptions --- Eliminate mention of `remove` exception 🔬 

### DIFF
--- a/src/site/topics/exceptions/exceptions.rst
+++ b/src/site/topics/exceptions/exceptions.rst
@@ -110,9 +110,8 @@ Catching Exceptions
 * If someone is using the ``ArraySortedBag`` implementation two years from now, it's not possible to know what they should do to manage the exceptional situations
 * The users of the ``ArraySortedBag`` class will need to deal with them as they see fit
 
-    * What should be done if calling ``remove`` on an empty ``ArraySortedBag``?
-    * What should be done if calling ``remove`` when the element does not exist within the ``ArraySortedBag``?
-
+    * What should be done if calling ``removeFirst`` on an empty ``ArraySortedBag``?
+    
 
 Ignore
 ------


### PR DESCRIPTION
### Related Issues or PRs
Effectively duplicate of #1038 

### What
Remove mention of the `remove` exception, but update the wording to say `removeFirst`

### Why
`removeFirst` throws an exception, `remove` does not, although it did in a previous version of the code from a few years back. 

### Testing
YOLO

### Additional Notes
If #1038 gets updated, I will close this PR and merge that one. 