### PR TITLE
:bug: Topic tree add --- Fix height definition 

### DIFF
--- a/src/site/topics/trees/tree-adt.rst
+++ b/src/site/topics/trees/tree-adt.rst
@@ -150,7 +150,7 @@ Properties
         * The level of a node that is not the root is the level of its parent ``+ 1``
 
 
-* The **height** of a tree is the number of levels the tree has
+* The **height** of a tree is the maximum level of the tree's nodes
 
 .. figure:: tree_path.png
     :width: 500 px


### PR DESCRIPTION
### What
Fix the definition of the tree height 

### Why
It was wrong before as the number of levels is weird since one would count 0

Basically, a tree with 4 levels has levels `0`, `1`, `2` and `3`, meaning the height would be 4. However, the height should be 3.  

### Testing
Nah