### PR TITLE
:lipstick: :mortar_board: Topic binary search trees --- Mention that a binary search was shown above :microscope: 

### DIFF
--- a/src/site/topics/trees/binary-search-trees.rst
+++ b/src/site/topics/trees/binary-search-trees.rst
@@ -379,6 +379,7 @@ Contains
 --------
 
 * Like the other data structures, a way to check if a given element exists within the collection is needed
+* This would be the binary search as described above
 * Although an exhaustive depth first search through the tree would work, as discussed for the general binary tree would work
 
     * :math:`O(n)`


### PR DESCRIPTION
### What
Remind that the contains was discussed above when going over the binary search. 

### Why
The way the content is presented is a little confusing. It seems like it's the analysis of a binary search, which would belong above when showing the binary search. However, it's presented here because it's specifically mentioning the contains operation, which is under the binary search tree operations section. 

To resolve this, I make it clearer that the method's implementation would be what was discussed above. 